### PR TITLE
Re-submit for updates to openCryptoki's internal crypto routines

### DIFF
--- a/usr/lib/pkcs11/common/defs.h
+++ b/usr/lib/pkcs11/common/defs.h
@@ -569,4 +569,24 @@ typedef struct _DL_NODE
   #pragma pack() 
 #endif
 
+/* internal crypto API */
+#define OP_ENCRYPT	1
+#define OP_DECRYPT	0
+
+#define AES_IV_SIZE	AES_BLOCK_SIZE
+#define DES3_IV_SIZE	DES_BLOCK_SIZE
+#define MAX_IV_LEN	AES_IV_SIZE
+
+int
+__aes_cbc(CK_BYTE *in_data, CK_ULONG in_data_len,
+	  CK_BYTE *out_data, CK_ULONG *out_data_len,
+	  CK_BYTE *key, ssize_t key_len, CK_BYTE *iv, int encrypt);
+
+int
+__des3_cbc(CK_BYTE *in_data, CK_ULONG in_data_len,
+	   CK_BYTE *out_data, CK_ULONG *out_data_len,
+	   CK_BYTE *key, ssize_t key_len, CK_BYTE *iv, int encrypt);
+
+int __md5(CK_BYTE *in_data, CK_ULONG in_data_len, CK_BYTE *hash);
+int __sha1(CK_BYTE *in_data, CK_ULONG in_data_len, CK_BYTE *hash);
 #endif

--- a/usr/lib/pkcs11/common/internal_crypto.c
+++ b/usr/lib/pkcs11/common/internal_crypto.c
@@ -1,0 +1,250 @@
+/*
+ * The Initial Developer of the Original Code is International
+ * Business Machines Corporation. Portions created by IBM
+ * Corporation are Copyright (C) 2011 International Business
+ * Machines Corporation. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the Common Public License as published by
+ * IBM Corporation; either version 1 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * Common Public License for more details.
+ *
+ * You should have received a copy of the Common Public License
+ * along with this program; if not, a copy can be viewed at
+ * http://www.opensource.org/licenses/cpl1.0.php.
+ */
+
+/*
+ * internal_crypto.c
+ *
+ * Oct 14, 2011
+ *
+ * Author: Kent Yoder <yoder1@us.ibm.com>
+ *
+ * Encryption routines for the Linux kernel's user-space crypto APIs
+ *
+ */
+
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <linux/if_alg.h>
+
+#include "pkcs11types.h"
+#include "defs.h"
+#include "host_defs.h"
+#include "h_extern.h"
+
+
+static int
+_setup_tfm(int *tfm, char *type, const char *name)
+{
+	struct sockaddr_alg sa = {
+		.salg_family = AF_ALG,
+	};
+
+	*tfm = socket(AF_ALG, SOCK_SEQPACKET, 0);
+	if (*tfm == -1) {
+		OCK_LOG_DEBUG("%s:%s: socket(): %s", type, name, strerror(errno));
+		return -1;
+	}
+
+	strncpy(sa.salg_type, type, strlen(type)+1);
+	strncpy(sa.salg_name, name, strlen(name)+1);
+	if (bind(*tfm, (struct sockaddr*)&sa, sizeof(sa)) == -1) {
+		OCK_LOG_DEBUG("%s:%s: bind(): %s", type, name, strerror(errno));
+		close(*tfm);
+		return -1;
+	}
+
+	return 0;
+}
+
+
+static int
+__cipher_cbc(const char *name, CK_BYTE *in_data, CK_ULONG in_data_len,
+	     CK_BYTE *out_data, CK_ULONG *out_data_len,
+	     CK_BYTE *key, ssize_t key_len, CK_BYTE *iv, CK_ULONG ivlen, int encrypt)
+{
+	uint32_t type;
+	struct iovec iov;
+	ssize_t len;
+	char buf[CMSG_SPACE(sizeof(type)) +
+		 CMSG_SPACE(offsetof(struct af_alg_iv, iv) + MAX_IV_LEN)] = { 0, };
+	struct msghdr msg = { 0, };
+	struct cmsghdr *cmsg;
+	struct af_alg_iv *ivm;
+	struct sockaddr_alg sa = {
+		.salg_family = AF_ALG,
+		.salg_type = "skcipher",
+	};
+	int tfm, rc, op;
+
+	if (*out_data_len < in_data_len) {
+		OCK_LOG_DEBUG("not enough space in out_data");
+		return EINVAL;
+	}
+
+	rc = _setup_tfm(&tfm, "skcipher", name);
+	if (rc) {
+		OCK_LOG_DEBUG("setup_tfm failed\n");
+		goto err;
+	}
+
+	if (setsockopt(tfm, SOL_ALG, ALG_SET_KEY, key, (socklen_t)key_len) == -1) {
+		OCK_LOG_DEBUG("setsockopt() failed: %s", strerror(errno));
+		rc = -1;
+		goto err;
+	}
+
+	op = accept(tfm, NULL, 0);
+	if (op == -1) {
+		OCK_LOG_DEBUG("accept() failed: %s", strerror(errno));
+		rc = -1;
+		goto err;
+	}
+
+	type = encrypt ? ALG_OP_ENCRYPT : ALG_OP_DECRYPT;
+
+	msg.msg_control = buf;
+	msg.msg_controllen = sizeof(buf);
+
+	/*
+	 *   POSIX 1003.1g - ancillary data object information
+	 *   Ancillary data consits of a sequence of pairs of
+	 *   (cmsghdr, cmsg_data[])
+	 */
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_level = SOL_ALG;
+	cmsg->cmsg_type = ALG_SET_OP;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(type));
+	*(uint32_t *)CMSG_DATA(cmsg) = type;
+
+	cmsg = CMSG_NXTHDR(&msg, cmsg);
+	cmsg->cmsg_level = SOL_ALG;
+	cmsg->cmsg_type = ALG_SET_IV;
+	cmsg->cmsg_len = CMSG_LEN(offsetof(struct af_alg_iv, iv) + ivlen);
+
+	/* get a pointer to the tail of the second cmsg */
+	ivm = (void *)CMSG_DATA(cmsg);
+	ivm->ivlen = ivlen;
+	memcpy(ivm->iv, iv, ivlen);
+
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	iov.iov_base = in_data;
+	iov.iov_len = in_data_len;
+
+	len = sendmsg(op, &msg, 0);
+	if (len != in_data_len) {
+		OCK_LOG_DEBUG("sendmsg() failed: %s. "
+				"Tried to send %u bytes, only sent %zd\n",
+				strerror(errno), in_data_len, len);
+		close(op);
+		goto err;
+	}
+
+	if (read(op, out_data, len) != in_data_len) {
+		OCK_LOG_DEBUG("read() failed: %s. Tried to read %u bytes, only read %zd",
+				strerror(errno), len, in_data_len);
+		close(op);
+		goto err;
+	}
+
+	return 0;
+err:
+	close(tfm);
+	return 1;
+}
+
+int
+__aes_cbc(CK_BYTE *in_data, CK_ULONG in_data_len,
+	  CK_BYTE *out_data, CK_ULONG *out_data_len,
+	  CK_BYTE *key, ssize_t key_len, CK_BYTE *iv, int encrypt)
+{
+	return __cipher_cbc("cbc(aes)", in_data, in_data_len, out_data, out_data_len, key, key_len,
+			    iv, AES_IV_SIZE, encrypt);
+}
+
+int
+__des3_cbc(CK_BYTE *in_data, CK_ULONG in_data_len,
+	   CK_BYTE *out_data, CK_ULONG *out_data_len,
+	   CK_BYTE *key, ssize_t key_len, CK_BYTE *iv, int encrypt)
+{
+	return __cipher_cbc("cbc(des3_ede)", in_data, in_data_len, out_data, out_data_len, key,
+			    key_len, iv, DES3_IV_SIZE, encrypt);
+}
+
+static int
+__digest(const char *name, CK_BYTE *data, CK_ULONG data_len, CK_BYTE *hash, CK_ULONG hash_len)
+{
+	int tfm, op, rc;
+	struct iovec iov;
+	struct msghdr msg = { 0, };
+	ssize_t len;
+
+	rc = _setup_tfm(&tfm, "hash", name);
+	if (rc) {
+		OCK_LOG_DEBUG("setup_tfm failed\n");
+		return rc;
+	}
+
+	op = accept(tfm, NULL, 0);
+	if (op == -1) {
+		OCK_LOG_DEBUG("accept() failed: %s", strerror(errno));
+		rc = -1;
+		goto err;
+	}
+
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	iov.iov_base = data;
+	iov.iov_len = data_len;
+
+	len = sendmsg(op, &msg, 0);
+	if (len != data_len) {
+		OCK_LOG_DEBUG("sendmsg() failed: %s. "
+			      "Tried to send %u bytes, only sent %zd\n",
+			      strerror(errno), data_len, len);
+		close(op);
+		rc = -1;
+		goto err;
+	}
+
+	if ((len = read(op, hash, hash_len)) != hash_len) {
+		OCK_LOG_DEBUG("read() failed: %s. Tried to read %u bytes, only read %zd",
+				strerror(errno), hash_len, len);
+		close(op);
+		rc = -1;
+		goto err;
+	}
+err:
+	close(tfm);
+	return rc;
+}
+
+int
+__md5(CK_BYTE *in_data, CK_ULONG in_data_len, CK_BYTE *hash)
+{
+	return __digest("md5", in_data, in_data_len, hash, MD5_HASH_SIZE);
+}
+
+int
+__sha1(CK_BYTE *in_data, CK_ULONG in_data_len, CK_BYTE *hash)
+{
+	return __digest("sha1", in_data, in_data_len, hash, SHA1_HASH_SIZE);
+}
+
+

--- a/usr/lib/pkcs11/common/loadsave.c
+++ b/usr/lib/pkcs11/common/loadsave.c
@@ -653,9 +653,8 @@ save_private_token_object( OBJECT *obj )
    initial_vector = (CK_BYTE *)alloca(strlen("10293847")+5);
    if (initial_vector) {	
       memcpy(initial_vector, "10293847", strlen("10293847"));
-      rc = ckm_des3_cbc_encrypt( cleartxt,    padded_len,
-				 ciphertxt,  &ciphertxt_len,
-			         initial_vector, des3_key );
+      rc = __des3_cbc(cleartxt, padded_len, ciphertxt, &ciphertxt_len, des3_key, sizeof(des3_key),
+		      initial_vector, OP_ENCRYPT);
    } else {
       OCK_LOG_ERR(ERR_HOST_MEMORY);
       rc = CKR_HOST_MEMORY;
@@ -908,9 +907,8 @@ restore_private_token_object( CK_BYTE  * data,
    initial_vector = (CK_BYTE *)alloca(strlen("10293847")+5);
    if (initial_vector) {
       memcpy(initial_vector, "10293847", strlen("10293847"));
-      rc = ckm_des3_cbc_decrypt( ciphertxt,    len,
-                                 cleartxt,  &len,
-                                 initial_vector, des3_key );
+      rc = __des3_cbc(ciphertxt, len, cleartxt, &len, des3_key, sizeof(des3_key), initial_vector,
+		      OP_DECRYPT);
    } else {
       OCK_LOG_ERR(ERR_HOST_MEMORY);
       rc = CKR_HOST_MEMORY;
@@ -1035,9 +1033,8 @@ load_masterkey_so( void )
    initial_vector = (CK_BYTE *)alloca(strlen("12345678")+5);
    if (initial_vector) {
       memcpy(initial_vector, "12345678", strlen("12345678"));
-      rc = ckm_des3_cbc_decrypt( cipher,  cipher_len,
-                                 clear,  &clear_len,
-                                 initial_vector, des3_key );
+      rc = __des3_cbc(cipher, cipher_len, clear, &clear_len, des3_key, sizeof(des3_key),
+		      initial_vector, OP_DECRYPT);
    } else {
       OCK_LOG_ERR(ERR_HOST_MEMORY);
       rc = CKR_HOST_MEMORY;
@@ -1135,9 +1132,8 @@ load_masterkey_user( void )
    initial_vector = (CK_BYTE *)alloca(strlen("12345678")+5);
    if (initial_vector) {
       memcpy(initial_vector, "12345678", strlen("12345678"));
-      rc = ckm_des3_cbc_decrypt( cipher,  cipher_len,
-                                 clear,  &clear_len,
-                                 initial_vector, des3_key );
+      rc = __des3_cbc(cipher, cipher_len, clear, &clear_len, des3_key, sizeof(des3_key),
+		      initial_vector, OP_DECRYPT);
    } else {
       OCK_LOG_ERR(ERR_HOST_MEMORY);
       rc = CKR_HOST_MEMORY;
@@ -1223,9 +1219,8 @@ save_masterkey_so( void )
    initial_vector = (CK_BYTE *)alloca(strlen("12345678"));
    if (initial_vector) {
       memcpy(initial_vector, "12345678", strlen("12345678"));
-      rc = ckm_des3_cbc_encrypt( cleartxt,    padded_len,
-                                 ciphertxt,  &ciphertxt_len,
-                                 initial_vector, des3_key );
+      rc = __des3_cbc(cleartxt, padded_len, ciphertxt,  &ciphertxt_len, des3_key, sizeof(des3_key),
+		      initial_vector, OP_ENCRYPT );
    } else {
       OCK_LOG_ERR(ERR_HOST_MEMORY);
       rc = CKR_HOST_MEMORY;
@@ -1309,9 +1304,8 @@ save_masterkey_user( void )
    initial_vector = (CK_BYTE *)alloca(strlen("12345678")+5);
    if (initial_vector) {
       memcpy(initial_vector, "12345678", strlen("12345678"));
-      rc = ckm_des3_cbc_encrypt( cleartxt,    padded_len,
-                                 ciphertxt,  &ciphertxt_len,
-                                 initial_vector, des3_key );
+      rc = __des3_cbc(cleartxt, padded_len, ciphertxt, &ciphertxt_len, des3_key, sizeof(des3_key),
+		      initial_vector, OP_ENCRYPT );
    } else {
       OCK_LOG_ERR(ERR_HOST_MEMORY);
       rc = CKR_HOST_MEMORY;

--- a/usr/lib/pkcs11/common/utility.c
+++ b/usr/lib/pkcs11/common/utility.c
@@ -1318,21 +1318,10 @@ compute_sha( CK_BYTE  * data,
              CK_ULONG   len,
              CK_BYTE  * hash )
 {
-   // XXX KEY
-   DIGEST_CONTEXT	ctx;
-   CK_ULONG     	hash_len = SHA1_HASH_SIZE;
-   CK_RV		rv;
+   int rc = __sha1(data, len, hash);
 
-   memset( &ctx, 0x0, sizeof(ctx) );
-
-   ckm_sha1_init( &ctx );
-   if( ctx.context == NULL )
-	   return CKR_HOST_MEMORY;
-   
-   if( (rv = ckm_sha1_update( &ctx, data,  len )) != CKR_OK)
-	   return rv;
-   
-   return ckm_sha1_final( &ctx, hash, &hash_len );
+   OCK_LOG_DEBUG("%s failed\n", __FUNCTION__);
+   return rc;
 }
 
 
@@ -1341,15 +1330,9 @@ compute_md5( CK_BYTE  * data,
              CK_ULONG   len,
              CK_BYTE  * hash )
 {
-   MD5_CONTEXT ctx;
-
-   memset( &ctx, 0x0, sizeof(ctx) );
-
-   ckm_md5_init( &ctx );
-   ckm_md5_update( &ctx, data,  len );
-   ckm_md5_final(  &ctx, hash, MD5_HASH_SIZE );
-
-   return CKR_OK;
+   int rc = __md5(data, len, hash);
+   OCK_LOG_DEBUG("%s failed\n", __FUNCTION__);
+   return rc;
 }
 
 

--- a/usr/lib/pkcs11/ica_s390_stdll/Makefile.am
+++ b/usr/lib/pkcs11/ica_s390_stdll/Makefile.am
@@ -20,7 +20,7 @@ opencryptoki_stdll_libpkcs11_ica_la_SOURCES = ../common/asn1.c	\
 ../common/obj_mgr.c ../common/object.c ../common/sess_mgr.c	\
 ../common/sign_mgr.c ../common/template.c ../common/p11util.c	\
 ../common/utility.c ../common/verify_mgr.c ../common/log.c	\
-../common/mech_list.c ica_specific.c
+../common/mech_list.c ../internal_crypto.c ica_specific.c
 
 INCLUDES = $(ICA_INC_DIRS) -I. -I../../../include/pkcs11/stdll	\
 -I../../../include/pkcs11 -I../common -I../../../ica/inc	\

--- a/usr/lib/pkcs11/soft_stdll/Makefile.am
+++ b/usr/lib/pkcs11/soft_stdll/Makefile.am
@@ -23,6 +23,7 @@ opencryptoki_stdll_libpkcs11_sw_la_SOURCES = ../common/asn1.c		\
 					     ../common/dig_mgr.c	\
 					     ../common/encr_mgr.c	\
 					     ../common/globals.c	\
+					     ../common/internal_crypto.c\
 					     ../common/loadsave.c	\
 					     ../common/key.c		\
 					     ../common/key_mgr.c	\


### PR DESCRIPTION
This update changes the callers of opencryptoki's internal md5/sha1
routines to use the linux kernel's user-space crypto API. To test, this
requires a recent kernel -- this is tested against 3.1.0-rc9+. Given
that this is a linux-specific feature, we'll likely want to push this
into the next major release instead of a minor release.

There are two paths to opencryptoki's internal md5/sha1 routines, one is
through compute_sha/compute_md5 in usr/lib/pkcs11/common/utility.c,
which is called by opencryptoki internally to do things like integrity
checks on the token data objects. The other is through mech_md5.c and
mech_sha1.c in usr/lib/pkcs11/common, which provides the interfaces
called by the application.

This patch only replaces the calls made from utility.c for the internal
crypto routines. Follow on patches will need to replace the application
facing interfaces so that the internal routines can be completely
removed. At that point opencryptoki can be completely independent of any
user-space crypto library.

Signed-off-by: Kent Yoder key@linux.vnet.ibm.com
