### PR TITLE
Remove all the extra locking schemes that are never used to guard

### DIFF
--- a/usr/include/pkcs11/slotmgr.h
+++ b/usr/include/pkcs11/slotmgr.h
@@ -320,10 +320,7 @@
     #define TOK_PATH  SBIN_PATH "/pkcsslotd"
 #endif /* DEV */
 
-#if (SPINXPL)
 #define  XPL_FILE  "/tmp/.pkapi_xpk"
-#endif
-
 
 #define PID_FILE_PATH "/var/run/pkcsslotd.pid"
 

--- a/usr/lib/pkcs11/api/Makefile.am
+++ b/usr/lib/pkcs11/api/Makefile.am
@@ -9,7 +9,7 @@ opencryptoki_libopencryptoki_la_LDFLAGS = -shared -Wl,-Bsymbolic -lc -ldl \
 					  $(SO_CURRENT):$(SO_REVISION):$(SO_AGE)
 
 # Not all versions of automake observe libname_CFLAGS
-opencryptoki_libopencryptoki_la_CFLAGS = -DSPINXPL -DAPI -DDEV -D_THREAD_SAFE \
+opencryptoki_libopencryptoki_la_CFLAGS = -DAPI -DDEV -D_THREAD_SAFE 		\
 					 -fPIC -I../. -I../../../include/pkcs11 \
 					 -I ../common -DSTDLL_NAME=\"api\"
 

--- a/usr/lib/pkcs11/api/apiproto.h
+++ b/usr/lib/pkcs11/api/apiproto.h
@@ -318,8 +318,8 @@ void API_UnRegister();
 int DL_Load_and_Init(API_Slot_t *,CK_SLOT_ID);
 
 
-int XProcLock(void *);
-int XProcUnLock(void *);
+int XProcLock(void);
+int XProcUnLock(void);
 
 void _init(void);
 void get_sess_count(CK_SLOT_ID, CK_ULONG *);

--- a/usr/lib/pkcs11/cca_stdll/Makefile.am
+++ b/usr/lib/pkcs11/cca_stdll/Makefile.am
@@ -7,7 +7,7 @@
 nobase_lib_LTLIBRARIES=opencryptoki/stdll/libpkcs11_cca.la
 
 # Not all versions of automake observe libname_CFLAGS
-opencryptoki_stdll_libpkcs11_cca_la_CFLAGS = -DLINUX -DSPINXPL -DNOCDMF	\
+opencryptoki_stdll_libpkcs11_cca_la_CFLAGS = -DLINUX -DNOCDMF		\
 	-DNODSA -DNODH -DNOECB						\
 	-I. -I../../../include	-I../../../include/pkcs11 -I../common	\
 	-DSTDLL_NAME=\"ccatok\"

--- a/usr/lib/pkcs11/cca_stdll/globals.c
+++ b/usr/lib/pkcs11/cca_stdll/globals.c
@@ -41,12 +41,6 @@ CK_BBOOL        initialized = FALSE;
 pthread_mutex_t native_mutex ;
 MUTEX pkcs_mutex, obj_list_mutex, sess_list_mutex, login_mutex;
 
-#if SYSVSEM
-int   xprocsemid = -1;
-#endif
-
-void *xproclock;
-
 struct btree sess_btree = { NULL, NULL, 0UL, 0UL };
 struct btree sess_obj_btree = { NULL, NULL, 0UL, 0UL };
 struct btree publ_token_obj_btree = { NULL, NULL, 0UL, 0UL };

--- a/usr/lib/pkcs11/cca_stdll/h_extern.h
+++ b/usr/lib/pkcs11/cca_stdll/h_extern.h
@@ -44,12 +44,6 @@ extern MECH_LIST_ELEMENT  mech_list[];
 extern CK_ULONG           mech_list_len;
 
 extern pthread_mutex_t  native_mutex;
-#if SYSVSEM
-extern int xprocsemid;
-#endif
-
-
-extern  void *xproclock;
 
 extern MUTEX    pkcs_mutex, obj_list_mutex, sess_list_mutex, login_mutex;
 

--- a/usr/lib/pkcs11/cca_stdll/host_defs.h
+++ b/usr/lib/pkcs11/cca_stdll/host_defs.h
@@ -14,7 +14,6 @@
 #ifndef _HOST_DEFS_H
 #define _HOST_DEFS_H
 
-#include <semaphore.h>
 #include <pthread.h>
 #include <endian.h>
 
@@ -229,14 +228,6 @@ typedef struct _MD5_CONTEXT {
 // linux
 typedef pthread_mutex_t MUTEX;
 
-// This is actualy wrong... XPROC will be with spinlocks
-#if (SPINXPL)
-#define XPROCLOCK   unsigned int
-#else
-#define XPROCLOCK    MUTEX
-#endif
-
-
 typedef struct _TEMPLATE
 {
    DL_NODE  *attribute_list;
@@ -375,11 +366,6 @@ typedef struct _TOK_OBJ_ENTRY
 
 typedef struct _LW_SHM_TYPE
 {
-   XPROCLOCK      mutex;
-#if SYSVSEM
-   key_t	semtok;
-#endif
-
    TOKEN_DATA     nv_token_data;
    CK_ULONG_32       num_priv_tok_obj;
    CK_ULONG_32       num_publ_tok_obj;
@@ -394,10 +380,5 @@ typedef struct _LW_SHM_TYPE
 #define  MY_DestroyMutex(x)    _DestroyMutex((MUTEX *)(x))
 #define  MY_LockMutex(x)       _LockMutex((MUTEX *)(x))
 #define  MY_UnlockMutex(x)     _UnlockMutex((MUTEX *)(x))
-
-#define  MY_CreateMsem(x)     CreateXProcLock((void *)(x))
-#define  MY_DestroyMsem(x)    DestroyXProcLock((void *)(x))
-#define  MY_LockMsem(x)       XProcLock((void *)(x))
-#define  MY_UnlockMsem(x)     XProcUnLock((void *)(x))
 
 #endif

--- a/usr/lib/pkcs11/cca_stdll/loadsave.c
+++ b/usr/lib/pkcs11/cca_stdll/loadsave.c
@@ -71,7 +71,7 @@ load_token_data()
 
    sprintf((char *)fname,"%s/%s",(char *)pk_dir, PK_LITE_NV);
 
-   rc = XProcLock( xproclock );
+   rc = XProcLock();
    if (rc != CKR_OK){
       OCK_LOG_ERR(ERR_PROCESS_LOCK);
       goto out_nolock;
@@ -83,9 +83,9 @@ load_token_data()
       if (errno == ENOENT) {
          /* init_token_data may call save_token_data, which graps the 
           * xproclock, so we must release it around this call */
-         XProcUnLock( xproclock );
+         XProcUnLock();
          init_token_data();
-         rc = XProcLock( xproclock );
+         rc = XProcLock();
          if (rc != CKR_OK){
             OCK_LOG_ERR(ERR_PROCESS_LOCK);
             goto out_nolock;
@@ -121,7 +121,7 @@ load_token_data()
    rc = CKR_OK;
 
 out_unlock:
-   XProcUnLock( xproclock );
+   XProcUnLock();
 
 out_nolock:
    return rc;
@@ -141,7 +141,7 @@ save_token_data()
 
    sprintf((char *)fname,"%s/%s",pk_dir, PK_LITE_NV);
 
-   rc = XProcLock( xproclock );
+   rc = XProcLock();
    if (rc != CKR_OK){
       OCK_LOG_ERR(ERR_PROCESS_LOCK);
       goto out_nolock;
@@ -166,7 +166,7 @@ save_token_data()
    rc = CKR_OK;
 
 done:
-   XProcUnLock( xproclock );
+   XProcUnLock();
 
 out_nolock:
    return rc;

--- a/usr/lib/pkcs11/cca_stdll/new_host.c
+++ b/usr/lib/pkcs11/cca_stdll/new_host.c
@@ -103,19 +103,15 @@ st_Initialized()
 	return TRUE;
 }
 
-#ifdef SPINXPL
 extern int spinxplfd;
 extern int spin_created;
-#endif
 
 void
 Fork_Initializer(void)
 {
 
-#ifdef SPINXPL
 	spinxplfd = -1;
 	spin_created = 0;
-#endif
 
 	// Force logout.  This cleans out the private session and list
 	// and cleans out the private object map
@@ -347,10 +343,6 @@ ST_Initialize(void **FunctionList,
 	// Handle global initialization issues first if we have not
 	// been initialized.
 	if (st_Initialized() == FALSE){
-#if SYSVSEM
-		xproclock = (void *)&xprocsemid;
-		CreateXProcLock(xproclock);
-#endif
 		if ( (rc = attach_shm()) != CKR_OK) {
 			OCK_LOG_ERR(ERR_SHM);
 			goto done;
@@ -379,13 +371,15 @@ ST_Initialize(void **FunctionList,
 		goto done;
 	}
 
-	/* no need to return error here, that would only prevent the stdll from loading. We load
-	 * the token objects that we can and syslog the rest */
+	/* no need to return error here, that would only prevent the stdll
+	 * from loading. We load the token objects that we can and syslog
+	 * the rest
+	 */
 	load_public_token_objects();
 
-	XProcLock( xproclock );
+	XProcLock();
 	global_shm->publ_loaded = TRUE;
-	XProcUnLock( xproclock );
+	XProcUnLock();
 
 	init_slotInfo();
 
@@ -817,7 +811,7 @@ CK_RV SC_InitPIN( ST_SESSION_HANDLE  *sSession,
 		OCK_LOG_ERR(ERR_HASH_COMPUTATION); 	
 		goto done;
 	}
-	rc = XProcLock( xproclock );
+	rc = XProcLock();
 	if (rc != CKR_OK){
 		OCK_LOG_ERR(ERR_PROCESS_LOCK);
 		goto done;
@@ -826,7 +820,7 @@ CK_RV SC_InitPIN( ST_SESSION_HANDLE  *sSession,
 	nv_token_data->token_info.flags |= CKF_USER_PIN_INITIALIZED;
 	nv_token_data->token_info.flags &= ~(CKF_USER_PIN_TO_BE_CHANGED);
 	nv_token_data->token_info.flags &= ~(CKF_USER_PIN_LOCKED);
-	XProcUnLock(xproclock);
+	XProcUnLock();
 	memcpy( user_pin_md5, hash_md5, MD5_HASH_SIZE  );
 	rc = save_token_data();
 	if (rc != CKR_OK){
@@ -912,7 +906,7 @@ CK_RV SC_SetPIN( ST_SESSION_HANDLE  *sSession,
 			rc = CKR_PIN_INVALID;
 			goto done;
 		}
-		rc = XProcLock( xproclock );
+		rc = XProcLock();
 		if (rc != CKR_OK){
 			OCK_LOG_ERR(ERR_PROCESS_LOCK);
 			goto done;
@@ -922,7 +916,7 @@ CK_RV SC_SetPIN( ST_SESSION_HANDLE  *sSession,
 		memcpy(user_pin_md5, hash_md5, MD5_HASH_SIZE);
 		nv_token_data->token_info.flags &=
 			~(CKF_USER_PIN_TO_BE_CHANGED);
-		XProcUnLock( xproclock );
+		XProcUnLock();
 		rc = save_token_data();
 		if (rc != CKR_OK){
 			OCK_LOG_ERR(ERR_TOKEN_SAVE);
@@ -951,7 +945,7 @@ CK_RV SC_SetPIN( ST_SESSION_HANDLE  *sSession,
 			rc = CKR_PIN_INVALID;
 			goto done;
 		}
-		rc = XProcLock( xproclock );
+		rc = XProcLock();
 		if (rc != CKR_OK){
 			OCK_LOG_ERR(ERR_PROCESS_LOCK);
 			goto done;
@@ -959,7 +953,7 @@ CK_RV SC_SetPIN( ST_SESSION_HANDLE  *sSession,
 		memcpy(nv_token_data->so_pin_sha, new_hash_sha, SHA1_HASH_SIZE);
 		memcpy( so_pin_md5, hash_md5, MD5_HASH_SIZE );
 		nv_token_data->token_info.flags &= ~(CKF_SO_PIN_TO_BE_CHANGED);
-		XProcUnLock( xproclock );
+		XProcUnLock();
 		rc = save_token_data();
 		if (rc != CKR_OK){
 			OCK_LOG_ERR(ERR_TOKEN_SAVE);
@@ -1317,13 +1311,15 @@ CK_RV SC_Login( ST_SESSION_HANDLE   *sSession,
 			OCK_LOG_ERR(ERR_MASTER_KEY_LOAD);
 			goto done;
 		}
-		/* no need to return error here, that would only prevent the stdll from loading. We
-		 * load the token objects that we can and syslog the rest */
+		/* no need to return error here, that would only prevent the
+		 * stdll from loading. We load the token objects that we can
+		 * and syslog the rest
+		 */
 		load_private_token_objects();
 
-		XProcLock( xproclock );
+		XProcLock();
 		global_shm->priv_loaded = TRUE;
-		XProcUnLock( xproclock );
+		XProcUnLock();
 
 	}
 	else {

--- a/usr/lib/pkcs11/common/globals.c
+++ b/usr/lib/pkcs11/common/globals.c
@@ -317,12 +317,6 @@ CK_BBOOL        initialized = FALSE;
 pthread_mutex_t native_mutex ;
 MUTEX pkcs_mutex, obj_list_mutex, sess_list_mutex, login_mutex;
 
-#if SYSVSEM
-int   xprocsemid = -1;
-#endif
-
-void *xproclock;
-
 struct btree sess_btree = { NULL, NULL, 0UL, 0UL };
 struct btree sess_obj_btree = { NULL, NULL, 0UL, 0UL };
 struct btree publ_token_obj_btree = { NULL, NULL, 0UL, 0UL };

--- a/usr/lib/pkcs11/common/h_extern.h
+++ b/usr/lib/pkcs11/common/h_extern.h
@@ -328,12 +328,6 @@ extern MECH_LIST_ELEMENT  mech_list[];
 extern CK_ULONG           mech_list_len;
 
 extern pthread_mutex_t  native_mutex;
-#if SYSVSEM
-extern int xprocsemid;
-#endif
-
-
-extern  void *xproclock;
 
 extern MUTEX    pkcs_mutex, obj_list_mutex, sess_list_mutex, login_mutex;
 

--- a/usr/lib/pkcs11/common/host_defs.h
+++ b/usr/lib/pkcs11/common/host_defs.h
@@ -298,7 +298,6 @@
 #ifndef _HOST_DEFS_H
 #define _HOST_DEFS_H
 
-#include <semaphore.h>
 #include <pthread.h>
 #include <endian.h>
 
@@ -514,12 +513,6 @@ typedef struct _MD5_CONTEXT {
 typedef pthread_mutex_t MUTEX;
 
 // This is actualy wrong... XPROC will be with spinlocks
-#if (SPINXPL)
-#define XPROCLOCK   unsigned int
-#else
-#define XPROCLOCK    MUTEX
-#endif
-
 
 typedef struct _TEMPLATE
 {
@@ -659,11 +652,6 @@ typedef struct _TOK_OBJ_ENTRY
 
 typedef struct _LW_SHM_TYPE
 {
-   XPROCLOCK      mutex;
-#if SYSVSEM
-   key_t	semtok;
-#endif
-
    TOKEN_DATA     nv_token_data;
    CK_ULONG_32       num_priv_tok_obj;
    CK_ULONG_32       num_publ_tok_obj;
@@ -678,10 +666,5 @@ typedef struct _LW_SHM_TYPE
 #define  MY_DestroyMutex(x)    _DestroyMutex((MUTEX *)(x))
 #define  MY_LockMutex(x)       _LockMutex((MUTEX *)(x))
 #define  MY_UnlockMutex(x)     _UnlockMutex((MUTEX *)(x))
-
-#define  MY_CreateMsem(x)     CreateXProcLock((void *)(x))
-#define  MY_DestroyMsem(x)    DestroyXProcLock((void *)(x))
-#define  MY_LockMsem(x)       XProcLock((void *)(x))
-#define  MY_UnlockMsem(x)     XProcUnLock((void *)(x))
 
 #endif

--- a/usr/lib/pkcs11/common/loadsave.c
+++ b/usr/lib/pkcs11/common/loadsave.c
@@ -359,7 +359,7 @@ load_token_data()
 
    sprintf((char *)fname,"%s/%s",(char *)pk_dir, PK_LITE_NV);
 
-   rc = XProcLock( xproclock );
+   rc = XProcLock();
    if (rc != CKR_OK){
       OCK_LOG_ERR(ERR_PROCESS_LOCK);
       goto out_nolock;
@@ -370,10 +370,10 @@ load_token_data()
       /* Better error checking added */
       if (errno == ENOENT) {
          /* init_token_data may call save_token_data, which graps the 
-          * xproclock, so we must release it around this call */
-         XProcUnLock( xproclock );
+          * lock, so we must release it around this call */
+         XProcUnLock();
          init_token_data();
-         rc = XProcLock( xproclock );
+         rc = XProcLock();
          if (rc != CKR_OK){
             OCK_LOG_ERR(ERR_PROCESS_LOCK);
             goto out_nolock;
@@ -410,7 +410,7 @@ load_token_data()
    rc = CKR_OK;
 
 out_unlock:
-   XProcUnLock( xproclock );
+   XProcUnLock();
 
 out_nolock:
    return rc;
@@ -430,7 +430,7 @@ save_token_data()
 
    sprintf((char *)fname,"%s/%s",pk_dir, PK_LITE_NV);
 
-   rc = XProcLock( xproclock );
+   rc = XProcLock();
    if (rc != CKR_OK){
       OCK_LOG_ERR(ERR_PROCESS_LOCK);
       goto out_nolock;
@@ -455,7 +455,7 @@ save_token_data()
    rc = CKR_OK;
 
 done:
-   XProcUnLock( xproclock );
+   XProcUnLock();
 
 out_nolock:
    return rc;

--- a/usr/lib/pkcs11/common/new_host.c
+++ b/usr/lib/pkcs11/common/new_host.c
@@ -631,10 +631,6 @@ ST_Initialize(void **FunctionList,
 	// Handle global initialization issues first if we have not
 	// been initialized.
 	if (st_Initialized() == FALSE){
-#if SYSVSEM
-		xproclock = (void *)&xprocsemid;
-		CreateXProcLock(xproclock);
-#endif
 		if ( (rc = attach_shm()) != CKR_OK) {
 			OCK_LOG_ERR(ERR_SHM);
 			goto done;
@@ -667,9 +663,9 @@ ST_Initialize(void **FunctionList,
 	/* no need to return error here, we load the token data we can and syslog the rest */
 	load_public_token_objects();
 
-	XProcLock( xproclock );
+	XProcLock();
 	global_shm->publ_loaded = TRUE;
-	XProcUnLock( xproclock );
+	XProcUnLock();
 
 	init_slotInfo();
 
@@ -1102,7 +1098,7 @@ CK_RV SC_InitPIN( ST_SESSION_HANDLE  *sSession,
 		OCK_LOG_ERR(ERR_HASH_COMPUTATION); 	
 		goto done;
 	}
-	rc = XProcLock( xproclock );
+	rc = XProcLock();
 	if (rc != CKR_OK){
 		OCK_LOG_ERR(ERR_PROCESS_LOCK);
 		goto done;
@@ -1111,7 +1107,7 @@ CK_RV SC_InitPIN( ST_SESSION_HANDLE  *sSession,
 	nv_token_data->token_info.flags |= CKF_USER_PIN_INITIALIZED;
 	nv_token_data->token_info.flags &= ~(CKF_USER_PIN_TO_BE_CHANGED);
 	nv_token_data->token_info.flags &= ~(CKF_USER_PIN_LOCKED);
-	XProcUnLock(xproclock);
+	XProcUnLock();
 	memcpy( user_pin_md5, hash_md5, MD5_HASH_SIZE  );
 	rc = save_token_data();
 	if (rc != CKR_OK){
@@ -1197,7 +1193,7 @@ CK_RV SC_SetPIN( ST_SESSION_HANDLE  *sSession,
 			rc = CKR_PIN_INVALID;
 			goto done;
 		}
-		rc = XProcLock( xproclock );
+		rc = XProcLock();
 		if (rc != CKR_OK){
 			OCK_LOG_ERR(ERR_PROCESS_LOCK);
 			goto done;
@@ -1207,7 +1203,7 @@ CK_RV SC_SetPIN( ST_SESSION_HANDLE  *sSession,
 		memcpy(user_pin_md5, hash_md5, MD5_HASH_SIZE);
 		nv_token_data->token_info.flags &=
 			~(CKF_USER_PIN_TO_BE_CHANGED);
-		XProcUnLock( xproclock );
+		XProcUnLock();
 		rc = save_token_data();
 		if (rc != CKR_OK){
 			OCK_LOG_ERR(ERR_TOKEN_SAVE);
@@ -1236,7 +1232,7 @@ CK_RV SC_SetPIN( ST_SESSION_HANDLE  *sSession,
 			rc = CKR_PIN_INVALID;
 			goto done;
 		}
-		rc = XProcLock( xproclock );
+		rc = XProcLock();
 		if (rc != CKR_OK){
 			OCK_LOG_ERR(ERR_PROCESS_LOCK);
 			goto done;
@@ -1244,7 +1240,7 @@ CK_RV SC_SetPIN( ST_SESSION_HANDLE  *sSession,
 		memcpy(nv_token_data->so_pin_sha, new_hash_sha, SHA1_HASH_SIZE);
 		memcpy( so_pin_md5, hash_md5, MD5_HASH_SIZE );
 		nv_token_data->token_info.flags &= ~(CKF_SO_PIN_TO_BE_CHANGED);
-		XProcUnLock( xproclock );
+		XProcUnLock();
 		rc = save_token_data();
 		if (rc != CKR_OK){
 			OCK_LOG_ERR(ERR_TOKEN_SAVE);
@@ -1602,13 +1598,14 @@ CK_RV SC_Login( ST_SESSION_HANDLE  *sSession,
 			goto done;
 		}
 
-		/* no need to return error here, we load the token data we can and syslog the
-		 * rest */
+		/* no need to return error here, we load the token data
+		 * we can and syslog the rest
+		 */
 		load_private_token_objects();
 
-		XProcLock( xproclock );
+		XProcLock();
 		global_shm->priv_loaded = TRUE;
-		XProcUnLock( xproclock );
+		XProcUnLock();
 
 	}
 	else {

--- a/usr/lib/pkcs11/common/obj_mgr.c
+++ b/usr/lib/pkcs11/common/obj_mgr.c
@@ -411,7 +411,7 @@ object_mgr_add( SESSION          * sess,
       // we'll be modifying nv_token_data so we should protect this part with
       // the 'pkcs_mutex'
       //
-      rc = XProcLock( xproclock );
+      rc = XProcLock();
       if (rc != CKR_OK){
          OCK_LOG_ERR(ERR_PROCESS_LOCK); 
          goto done;
@@ -424,7 +424,7 @@ object_mgr_add( SESSION          * sess,
             if (global_shm->num_priv_tok_obj >= MAX_TOK_OBJS) {
                rc = CKR_HOST_MEMORY;
                OCK_LOG_ERR(ERR_HOST_MEMORY); 
-               XProcUnLock(xproclock);
+               XProcUnLock();
                goto done;
             }
          }
@@ -432,7 +432,7 @@ object_mgr_add( SESSION          * sess,
             if (global_shm->num_publ_tok_obj >= MAX_TOK_OBJS) {
                rc = CKR_HOST_MEMORY;
                OCK_LOG_ERR(ERR_HOST_MEMORY); 
-               XProcUnLock(xproclock);
+               XProcUnLock();
                goto done;
             }
          }
@@ -445,7 +445,7 @@ object_mgr_add( SESSION          * sess,
          rc = compute_next_token_obj_name( current, next );
          if (rc != CKR_OK) {
                  // TODO: handle error, check if rc is a valid per spec
-                XProcUnLock(xproclock);
+                XProcUnLock();
                  goto done;
          }
          memcpy( &nv_token_data->next_token_object_name, next, 8 );
@@ -453,7 +453,7 @@ object_mgr_add( SESSION          * sess,
          rc = save_token_object( o );
          if (rc != CKR_OK) {
                  // TODO: handle error, check if rc is a valid per spec
-                XProcUnLock(xproclock);
+                XProcUnLock();
                 goto done;
          }
 
@@ -461,14 +461,14 @@ object_mgr_add( SESSION          * sess,
          //
          object_mgr_add_to_shm( o );
 
-         XProcUnLock( xproclock );
+         XProcUnLock();
 
          // save_token_data has to lock the mutex itself because it's used elsewhere
          //
          rc = save_token_data();
          if (rc != CKR_OK) {
                  // TODO: handle error, check if rc is a valid per spec
-                XProcUnLock(xproclock);
+                XProcUnLock();
                 goto done;
          }
 
@@ -512,14 +512,14 @@ object_mgr_add( SESSION          * sess,
 	    bt_node_free(&publ_token_obj_btree, obj_handle, NULL);
          }
 
-         rc = XProcLock( xproclock );
+         rc = XProcLock();
          if (rc != CKR_OK){
             OCK_LOG_ERR(ERR_PROCESS_LOCK); 
             goto done;
          }
          object_mgr_del_from_shm( o );
 
-         XProcUnLock( xproclock );
+         XProcUnLock();
       }
    }
 
@@ -717,7 +717,7 @@ object_mgr_copy( SESSION          * sess,
       // we'll be modifying nv_token_data so we should protect this part
       // with 'pkcs_mutex'
       //
-      rc = XProcLock( xproclock );
+      rc = XProcLock();
       if (rc != CKR_OK){
          OCK_LOG_ERR(ERR_PROCESS_LOCK); 
          goto done;
@@ -728,7 +728,7 @@ object_mgr_copy( SESSION          * sess,
          //
          if (priv_obj) {
             if (global_shm->num_priv_tok_obj >= MAX_TOK_OBJS) {
-               XProcUnLock(xproclock);
+               XProcUnLock();
                OCK_LOG_ERR(ERR_HOST_MEMORY); 
                rc = CKR_HOST_MEMORY;
                goto done;
@@ -736,7 +736,7 @@ object_mgr_copy( SESSION          * sess,
          }
          else {
             if (global_shm->num_publ_tok_obj >= MAX_TOK_OBJS) {
-               XProcUnLock(xproclock);
+               XProcUnLock();
                OCK_LOG_ERR(ERR_HOST_MEMORY); 
                rc = CKR_HOST_MEMORY;
                goto done;
@@ -756,7 +756,7 @@ object_mgr_copy( SESSION          * sess,
          //
          object_mgr_add_to_shm( new_obj );
 
-         XProcUnLock( xproclock );
+         XProcUnLock();
 
          save_token_data();
       }
@@ -805,14 +805,14 @@ object_mgr_copy( SESSION          * sess,
 	    bt_node_free(&publ_token_obj_btree, obj_handle, NULL);
          }
 
-         rc = XProcLock( xproclock );
+         rc = XProcLock();
          if (rc != CKR_OK){
             OCK_LOG_ERR(ERR_PROCESS_LOCK); 
             goto done;
          }
          object_mgr_del_from_shm( new_obj );
 
-         XProcUnLock( xproclock );
+         XProcUnLock();
       }
    }
 
@@ -953,7 +953,7 @@ object_mgr_create_final( SESSION           * sess,
       // we'll be modifying nv_token_data so we should protect this part
       // with 'pkcs_mutex'
       //
-      rc = XProcLock( xproclock );
+      rc = XProcLock();
       if (rc != CKR_OK){
          OCK_LOG_ERR(ERR_PROCESS_LOCK); 
          goto done;
@@ -964,7 +964,7 @@ object_mgr_create_final( SESSION           * sess,
          //
          if (priv_obj) {
             if (global_shm->num_priv_tok_obj >= MAX_TOK_OBJS) {
-               XProcUnLock(xproclock);
+               XProcUnLock();
                OCK_LOG_ERR(ERR_HOST_MEMORY); 
                rc = CKR_HOST_MEMORY;
                goto done;
@@ -972,7 +972,7 @@ object_mgr_create_final( SESSION           * sess,
          }
          else {
             if (global_shm->num_publ_tok_obj >= MAX_TOK_OBJS) {
-               XProcUnLock(xproclock);
+               XProcUnLock();
                OCK_LOG_ERR(ERR_HOST_MEMORY); 
                rc = CKR_HOST_MEMORY;
                goto done;
@@ -992,7 +992,7 @@ object_mgr_create_final( SESSION           * sess,
          //
          object_mgr_add_to_shm( obj );
 
-         XProcUnLock( xproclock );
+         XProcUnLock();
 
          save_token_data();
       }
@@ -1040,14 +1040,14 @@ object_mgr_create_final( SESSION           * sess,
 	    bt_node_free(&publ_token_obj_btree, obj_handle, NULL);
          }
 
-         rc = XProcLock( xproclock );
+         rc = XProcLock();
          if (rc != CKR_OK){
             OCK_LOG_ERR(ERR_PROCESS_LOCK); 
             goto done;
          }
          object_mgr_del_from_shm( obj );
 
-         XProcUnLock( xproclock );
+         XProcUnLock();
       }
    }
 
@@ -1084,7 +1084,7 @@ destroy_object_cb(void *node)
 
 		/* Use the same calling convention as the old code, if XProcLock fails, don't
 		 * delete from shm and don't free the object in its other btree */
-		if (XProcLock(xproclock)) {
+		if (XProcLock()) {
 			OCK_LOG_ERR(ERR_PROCESS_LOCK);
 			goto done;
 		}
@@ -1092,7 +1092,7 @@ destroy_object_cb(void *node)
 		object_mgr_del_from_shm(o);
 		DUMP_SHM("after");
 
-		XProcUnLock( xproclock );
+		XProcUnLock();
 
 		if (map->is_private)
 			bt_node_free(&priv_token_obj_btree, map->obj_handle, object_free);
@@ -1165,14 +1165,14 @@ delete_token_obj_cb(void *node, unsigned long map_handle, void *p3)
 
 		/* Use the same calling convention as the old code, if XProcLock fails, don't
 		 * delete from shm and don't free the object in its other btree */
-		if (XProcLock(xproclock)) {
+		if (XProcLock()) {
 			OCK_LOG_ERR(ERR_PROCESS_LOCK);
 			goto done;
 		}
 
 		object_mgr_del_from_shm(o);
 
-		XProcUnLock( xproclock );
+		XProcUnLock();
 
 		if (map->is_private)
 			bt_node_free(&priv_token_obj_btree, map->obj_handle, object_free);
@@ -1203,7 +1203,7 @@ object_mgr_destroy_token_objects( void )
 
    // now we want to purge the token object list in shared memory
    //
-   rc = XProcLock( xproclock );
+   rc = XProcLock();
    if (rc == CKR_OK) {
       locked2 = TRUE;
 
@@ -1217,7 +1217,7 @@ object_mgr_destroy_token_objects( void )
       OCK_LOG_ERR(ERR_PROCESS_LOCK);
 done:
    if (locked1 == TRUE) MY_UnlockMutex( &obj_list_mutex );
-   if (locked2 == TRUE) XProcUnLock( xproclock );
+   if (locked2 == TRUE) XProcUnLock();
 
    return rc;
 }
@@ -1847,7 +1847,7 @@ object_mgr_restore_obj_withSize( CK_BYTE *data, OBJECT *oldObj, int data_size )
 	    }
 	 }
 
-         XProcLock( xproclock );
+         XProcLock();
            
          if (priv) {
             if (global_shm->priv_loaded == FALSE){
@@ -1869,7 +1869,7 @@ object_mgr_restore_obj_withSize( CK_BYTE *data, OBJECT *oldObj, int data_size )
             }
          }
 
-         XProcUnLock( xproclock );
+         XProcUnLock();
       } else {
          OCK_LOG_ERR(ERR_OBJ_RESTORE_DATA); 
       }
@@ -1981,7 +1981,7 @@ object_mgr_set_attribute_values( SESSION           * sess,
 
       save_token_object( obj );
 
-      rc = XProcLock( xproclock );
+      rc = XProcLock();
       if (rc != CKR_OK){
          OCK_LOG_ERR(ERR_PROCESS_LOCK); 
          return rc;
@@ -1993,7 +1993,7 @@ object_mgr_set_attribute_values( SESSION           * sess,
 
          if (rc != CKR_OK) {
             OCK_LOG_ERR(ERR_OBJMGR_SEARCH); 
-            XProcUnLock(xproclock);
+            XProcUnLock();
             return rc;
          }
 
@@ -2005,7 +2005,7 @@ object_mgr_set_attribute_values( SESSION           * sess,
                                              obj, &index );
          if (rc != CKR_OK) {
             OCK_LOG_ERR(ERR_OBJMGR_SEARCH); 
-            XProcUnLock(xproclock);
+            XProcUnLock();
             return rc;
          }
 
@@ -2015,7 +2015,7 @@ object_mgr_set_attribute_values( SESSION           * sess,
       entry->count_lo = obj->count_lo;
       entry->count_hi = obj->count_hi;
 
-      XProcUnLock( xproclock );
+      XProcUnLock();
    }
 
    return rc;

--- a/usr/lib/pkcs11/common/utility.c
+++ b/usr/lib/pkcs11/common/utility.c
@@ -569,18 +569,6 @@ _CreateMutex( MUTEX *mutex )
 }
 
 CK_RV
-_CreateMsem( sem_t *msem )
-{
-   if (!sem_init( msem,0, 1)) // parm 2 non-0 means pshared  1 is unlocked 0 is locked
-   //if (!sem_init( msem,1, 1)) // parm 2 non-0 means pshared  1 is unlocked 0 is locked
-      return CKR_OK;
-   else{
-      OCK_LOG_ERR(ERR_FUNCTION_FAILED);
-      return CKR_FUNCTION_FAILED;
-   }
-}
-
-CK_RV
 _DestroyMutex( MUTEX *mutex )
 {
      // no-op in AIX
@@ -588,18 +576,6 @@ _DestroyMutex( MUTEX *mutex )
      return CKR_OK;
 
 }
-
-CK_RV
-_DestroyMsem( sem_t *msem )
-{
-   if (!sem_destroy(msem))
-      return CKR_OK;
-   else{
-      OCK_LOG_ERR(ERR_FUNCTION_FAILED);
-      return CKR_FUNCTION_FAILED;
-   }
-}
-
 
 CK_RV
 _LockMutex( MUTEX *mutex )
@@ -610,59 +586,12 @@ _LockMutex( MUTEX *mutex )
 }
 
 CK_RV
-_LockMsem( sem_t *msem )
-{
-   if (!msem){
-      OCK_LOG_ERR(ERR_FUNCTION_FAILED);
-      return CKR_FUNCTION_FAILED;
-   }
-   if(!sem_wait(msem)) // block until the semaphore is free
-      return CKR_OK;
-   else{
-      OCK_LOG_ERR(ERR_FUNCTION_FAILED);
-      return CKR_FUNCTION_FAILED;
-   }
-}
-
-CK_RV
 _UnlockMutex( MUTEX *mutex )
 {
    pthread_mutex_unlock(mutex);
    return CKR_OK;
 
 }
-
-CK_RV
-_UnlockMsem( sem_t *msem )
-{
-   if (!msem){
-      OCK_LOG_ERR(ERR_FUNCTION_FAILED);
-      return CKR_FUNCTION_FAILED;
-   }
-   if (!sem_post(msem))
-      return CKR_OK;
-   else{
-      OCK_LOG_ERR(ERR_FUNCTION_FAILED);
-      return CKR_FUNCTION_FAILED;
-   }
-}
-
-#if SYSVSEM
-#include <sys/sem.h>
-// These structures are needed to effect a lock
-// using SYS V semaphores...
-static struct sembuf xlock_lock[2]={
-         0,0,0,
-         0,1,SEM_UNDO
-};
-
-static struct sembuf xlock_unlock[1] = {
-         0,-1,(IPC_NOWAIT | SEM_UNDO)
-};
-
-static pthread_mutex_t  semmtx = PTHREAD_MUTEX_INITIALIZER;
-
-#endif
 
 
 int spinxplfd=-1;
@@ -671,10 +600,9 @@ int spin_created=0;
 extern void set_perm(int);
 
 CK_RV
-CreateXProcLock(void *xproc)
+CreateXProcLock(void)
 {
 
-#if (SPINXPL)
     // open the file that we will do the locking on...
   spinxplfd = open("/tmp/.pkcs11spinloc",O_CREAT|O_APPEND|O_RDWR,
         S_IRWXU|S_IRWXG|S_IRWXO);
@@ -687,86 +615,17 @@ CreateXProcLock(void *xproc)
 	   perror("XPROC CREATE file :");
    }
     return CKR_OK;
-#elif  SYSVSEM
-   int  semid;
-   int *psem;
-   key_t  tok;
-
-   tok  = ftok( pk_dir, 'c' );
-  
-//printf("creating semaphore %x \n",tok);
-
-   psem = (int *)xproc;
-if ( *psem < 0 ) {
-   if ( (semid = semget(tok,1,IPC_CREAT | 0666)) < 0 ){
-      if (errno == EEXIST) {
-	  if ( (semid = semget(tok,0,0)) < 0) {
-		pthread_mutex_unlock(&semmtx);
-                OCK_LOG_ERR(ERR_FUNCTION_FAILED); 
-	        return CKR_FUNCTION_FAILED;
-	  }
-      } else {
-	      pthread_mutex_unlock(&semmtx);
-              OCK_LOG_ERR(ERR_FUNCTION_FAILED); 
-	      return CKR_FUNCTION_FAILED;
-      }
-   }
 }
-   psem = (int *)xproc;
-   *psem = semid;
-//pthread_mutex_unlock(&semmtx);
-   return CKR_OK;
 
-   // we know that semaphores are created unlocked
-#elif POSIXSEM 
-	return _CreateMsem((sem_t *)xproc);
-#elif PTHREADXPL
-	pthread_mutex_attr_t  mtxattr;
-
- 	pthread_mutexattr_init(&mtxattr);
-	pthread_mutexattr_setpshared(&mtxattr,PTHREAD_PROCESS_SHARED);
-	pthread_mutex_init((pthread_mutex_t *)xproc,&mtxattr);
-
-#elif  NOXPROCLOCK
-   return CKR_OK;
-#else
-#error "Define XPROC LOCKS"
-  
-#endif
-}
 CK_RV
-DestroyXProcLock(void *xproc)
+DestroyXProcLock(void)
 {
-#if SPINXPL
 	return CKR_OK;
-#elif SYSVSEM
-   int semid,*psem;
-
-//printf("Destroying semaphore %x \n",xproc);
-
-pthread_mutex_lock(&semmtx);
-   psem = (int *)xproc;
-   semid = *psem;
-
-   semctl(semid,1,IPC_RMID,0);
-pthread_mutex_unlock(&semmtx);
-
-   return CKR_OK;
-#elif POSIXSEM 
-	return _DestroyMsem((sem_t *)xproc);
-#elif  PTHREADXPL
-	return pthread_mutex_destroy((pthread_mutex_t *)xproc);
-#elif  NOXPROCLOCK
-   return CKR_OK;
-#else
-#error "Define XPROC LOCKS"
-#endif
 }
 
 CK_RV
-XProcLock(void *xproc)
+XProcLock(void)
 {
-#if SPINXPL
 	if (!spin_created) {
 	  spinxplfd = open("/tmp/.pkcs11spinloc",O_CREAT|O_APPEND|O_RDWR,
 		S_IRWXU|S_IRWXG|S_IRWXO);
@@ -777,33 +636,11 @@ XProcLock(void *xproc)
 		flock(spinxplfd,LOCK_EX);
 	}
 	return CKR_OK;
-#elif SYSVSEM
-   int semid,*psem;
-   pthread_mutex_lock(&semmtx);
-   return CKR_OK;
-
-   pthread_mutex_lock(&semmtx);
-   psem = (int *)xproc;
-   semid = *psem;
-   semop(semid,&xlock_lock[0],2);
-   pthread_mutex_unlock(&semmtx);
-   return CKR_OK;
-
-#elif POSIXSEM 
-	return _LockMsem((sem_t *)xproc);
-#elif PTHREADXPL
-	return _LockMutex((MUTEX *)xproc);
-#elif  NOXPROCLOCK
-   return CKR_OK;
-#else
-#error "Define XPROC LOCKS"
-
-#endif
 }
+
 CK_RV
-XProcUnLock(void *xproc)
+XProcUnLock(void)
 {
-#if SPINXPL
 	if (!spin_created) {
 	  spinxplfd = open("/tmp/.pkcs11spinloc",O_CREAT|O_APPEND|O_RDWR,
 		S_IRWXU|S_IRWXG|S_IRWXO);
@@ -814,26 +651,6 @@ XProcUnLock(void *xproc)
 		flock(spinxplfd,LOCK_UN);
 	}
 	return CKR_OK;
-#elif SYSVSEM
-   int semid,*psem;
-   pthread_mutex_unlock(&semmtx);
-   return CKR_OK;
-
-   pthread_mutex_lock(&semmtx);
-   psem = (int *)xproc;
-   semid = *psem;
-   semop(semid,&xlock_unlock[0],1);
-   pthread_mutex_unlock(&semmtx);
-   return CKR_OK;
-#elif POSIXSEM 
-	return _UnlockMsem((sem_t *)xproc);
-#elif PTHREADXPL
-	return _UnlockMutex((MUTEX *)xproc);
-#elif  NOXPROCLOCK
-   return CKR_OK;
-#else
-#error "Define XPROC LOCKS"
-#endif
 }
 
 
@@ -1205,23 +1022,13 @@ attach_shm()
       return CKR_FUNCTION_FAILED;
    }
    if (created == TRUE) {
-#if !(SYSVSEM)
-// SYSV sem's are a global that is handled in the 
-// Initialize routine...  all others are stored in the
-// shared memory segment so we have to do
-// this here after the segment is created
-// to prevent a core dump
-      CreateXProcLock( &global_shm->mutex );
-      xproclock = (void *)&global_shm->mutex; // need to do this here
-#endif
-      XProcLock( xproclock );
-         global_shm->num_publ_tok_obj = 0;
-         global_shm->num_priv_tok_obj = 0;
-         memset( &global_shm->publ_tok_objs, 0x0, 2048 * sizeof(TOK_OBJ_ENTRY) );
-         memset( &global_shm->priv_tok_objs, 0x0, 2048 * sizeof(TOK_OBJ_ENTRY) );
-      XProcUnLock( xproclock );
-   } else {
-	xproclock = (void *)&global_shm->mutex;
+      CreateXProcLock();
+      XProcLock();
+      global_shm->num_publ_tok_obj = 0;
+      global_shm->num_priv_tok_obj = 0;
+      memset( &global_shm->publ_tok_objs, 0x0, 2048 * sizeof(TOK_OBJ_ENTRY) );
+      memset( &global_shm->priv_tok_objs, 0x0, 2048 * sizeof(TOK_OBJ_ENTRY) );
+      XProcUnLock();
    }
 #elif MMAP
 	{
@@ -1270,14 +1077,12 @@ attach_shm()
 
 		global_shm = (LW_SHM_TYPE *)mmap(NULL,sizeof(LW_SHM_TYPE),PROT_READ|PROT_WRITE,MAP_SHARED,fd,0);
 		if (created == TRUE) {
-			XProcLock( xproclock );
+			XProcLock();
 			global_shm->num_publ_tok_obj = 0;
 			global_shm->num_priv_tok_obj = 0;
 			memset( &global_shm->publ_tok_objs, 0x0, 2048 * sizeof(TOK_OBJ_ENTRY) );
 			memset( &global_shm->priv_tok_objs, 0x0, 2048 * sizeof(TOK_OBJ_ENTRY) );
-			XProcUnLock( xproclock );
-		} else {
-			xproclock = (void *)&global_shm->mutex;
+			XProcUnLock();
 		}
 
 		rc = CKR_OK;

--- a/usr/lib/pkcs11/ica_s390_stdll/Makefile.am
+++ b/usr/lib/pkcs11/ica_s390_stdll/Makefile.am
@@ -5,7 +5,7 @@ $(ICA_LIB_DIRS) -nostartfiles -shared -Wl,-Bsymbolic -Wl,-soname,$@	\
 -Wl,-Bsymbolic -lc -lpthread -lica -ldl -lcrypto
 
 # Not all versions of automake observe libname_CFLAGS
-opencryptoki_stdll_libpkcs11_ica_la_CFLAGS = -DSPINXPL -DDEV		\
+opencryptoki_stdll_libpkcs11_ica_la_CFLAGS = -DDEV			\
 -D_THREAD_SAFE -fPIC -DSHALLOW=0 -DSWTOK=0 -DLITE=1 -DNODH 		\
 -DNOCDMF -DNOMD2 -DNODSA -DSTDLL_NAME=\"icatok\"
 

--- a/usr/lib/pkcs11/tpm_stdll/Makefile.am
+++ b/usr/lib/pkcs11/tpm_stdll/Makefile.am
@@ -9,7 +9,7 @@ AUTOMAKE_OPTIONS = gnu
 # TODO: -DLINUX and -DSPINXPL should be controlled via configure.in
 
 # Not all versions of automake observe libname_CFLAGS
-opencryptoki_stdll_libpkcs11_tpm_la_CFLAGS = -DLINUX -DSPINXPL -DNOCDMF	\
+opencryptoki_stdll_libpkcs11_tpm_la_CFLAGS = -DLINUX -DNOCDMF		\
 					     -DNODSA -DNODH		\
 					     -I. -I../../../include	\
 					     -I../../../include/pkcs11	\

--- a/usr/lib/pkcs11/tpm_stdll/globals.c
+++ b/usr/lib/pkcs11/tpm_stdll/globals.c
@@ -28,12 +28,6 @@ CK_BBOOL        initialized = FALSE;
 pthread_mutex_t  native_mutex ;
 MUTEX   pkcs_mutex, obj_list_mutex, sess_list_mutex, login_mutex;
 
-#if SYSVSEM
-int   xprocsemid = -1;
-#endif
-
-void *xproclock;
-
 struct btree sess_btree = { NULL, NULL, 0, 0 };
 struct btree sess_obj_btree = { NULL, NULL, 0, 0 };
 struct btree publ_token_obj_btree = { NULL, NULL, 0UL, 0UL };

--- a/usr/lib/pkcs11/tpm_stdll/h_extern.h
+++ b/usr/lib/pkcs11/tpm_stdll/h_extern.h
@@ -55,12 +55,6 @@ extern MECH_LIST_ELEMENT  mech_list[];
 extern CK_ULONG           mech_list_len;
 
 extern pthread_mutex_t  native_mutex;
-#if SYSVSEM
-extern int xprocsemid;
-#endif
-
-
-extern  void *xproclock;
 
 extern MUTEX    pkcs_mutex, obj_list_mutex, sess_list_mutex, login_mutex;
 

--- a/usr/lib/pkcs11/tpm_stdll/host_defs.h
+++ b/usr/lib/pkcs11/tpm_stdll/host_defs.h
@@ -6,7 +6,6 @@
 #ifndef _HOST_DEFS_H
 #define _HOST_DEFS_H
 
-#include <semaphore.h>
 #include <pthread.h>
 #include <endian.h>
 
@@ -219,14 +218,6 @@ typedef struct _MD5_CONTEXT {
 // linux
 typedef pthread_mutex_t MUTEX;
 
-// This is actualy wrong... XPROC will be with spinlocks
-#if (SPINXPL)
-#define XPROCLOCK   unsigned int
-#else
-#define XPROCLOCK    MUTEX
-#endif
-
-
 typedef struct _TEMPLATE
 {
    DL_NODE  *attribute_list;
@@ -343,11 +334,6 @@ typedef struct _TOK_OBJ_ENTRY
 
 typedef struct _LW_SHM_TYPE
 {
-   XPROCLOCK      mutex;
-#if SYSVSEM
-   key_t	semtok;
-#endif
-
    TOKEN_DATA     nv_token_data;
    CK_ULONG_32       num_priv_tok_obj;
    CK_ULONG_32       num_publ_tok_obj;
@@ -362,10 +348,5 @@ typedef struct _LW_SHM_TYPE
 #define  MY_DestroyMutex(x)    _DestroyMutex((MUTEX *)(x))
 #define  MY_LockMutex(x)       _LockMutex((MUTEX *)(x))
 #define  MY_UnlockMutex(x)     _UnlockMutex((MUTEX *)(x))
-
-#define  MY_CreateMsem(x)     CreateXProcLock((void *)(x))
-#define  MY_DestroyMsem(x)    DestroyXProcLock((void *)(x))
-#define  MY_LockMsem(x)       XProcLock((void *)(x))
-#define  MY_UnlockMsem(x)     XProcUnLock((void *)(x))
 
 #endif

--- a/usr/lib/pkcs11/tpm_stdll/loadsave.c
+++ b/usr/lib/pkcs11/tpm_stdll/loadsave.c
@@ -369,7 +369,7 @@ load_token_data()
 
    sprintf((char *)fname,"%s/%s/%s",(char *)pk_dir, pw->pw_name, PK_LITE_NV);
 
-   rc = XProcLock( xproclock );
+   rc = XProcLock();
    if (rc != CKR_OK){
       OCK_LOG_ERR(ERR_PROCESS_LOCK);
       goto out_nolock;
@@ -383,10 +383,10 @@ load_token_data()
       /* Better error checking added */
       if (errno == ENOENT) {
          /* init_token_data may call save_token_data, which graps the 
-          * xproclock, so we must release it around this call */
-         XProcUnLock( xproclock );
+          * lock, so we must release it around this call */
+         XProcUnLock();
          init_token_data();
-         rc = XProcLock( xproclock );
+         rc = XProcLock();
          if (rc != CKR_OK){
             OCK_LOG_ERR(ERR_PROCESS_LOCK);
             goto out_nolock;
@@ -440,7 +440,7 @@ load_token_data()
    rc = CKR_OK;
 
 out_unlock:
-   XProcUnLock( xproclock );
+   XProcUnLock();
 
 out_nolock:
    return rc;
@@ -468,7 +468,7 @@ save_token_data()
 
    sprintf((char *)fname,"%s/%s/%s",(char *)pk_dir, pw->pw_name, PK_LITE_NV);
 
-   rc = XProcLock( xproclock );
+   rc = XProcLock();
    if (rc != CKR_OK){
       OCK_LOG_ERR(ERR_PROCESS_LOCK);
       goto out_nolock;
@@ -513,7 +513,7 @@ save_token_data()
    rc = CKR_OK;
 
 done:
-   XProcUnLock( xproclock );
+   XProcUnLock();
 
 out_nolock:
    return rc;

--- a/usr/lib/pkcs11/tpm_stdll/new_host.c
+++ b/usr/lib/pkcs11/tpm_stdll/new_host.c
@@ -130,10 +130,8 @@ st_Initialized()
 }
 
 
-#ifdef SPINXPL
 extern int spinxplfd;
 extern int spin_created;
-#endif
 
 // ----------- SAB XXX XXX
 //
@@ -142,10 +140,8 @@ Fork_Initializer(void)
 {
   //    initialized == FALSE; // Get the initialization to be not true
 
-#ifdef SPINXPL
 	spinxplfd = -1;
 	spin_created = 0;
-#endif
 
 
           // Force logout.  This cleans out the private session and list
@@ -416,10 +412,6 @@ CK_RV ST_Initialize( void **FunctionList,
 	// Handle global initialization issues first if we have not
 	// been initialized.
 	if (st_Initialized() == FALSE){
-#if SYSVSEM
-		xproclock = (void *)&xprocsemid;
-		CreateXProcLock(xproclock);
-#endif
 		if ( (rc = attach_shm()) != CKR_OK) {
 			OCK_LOG_ERR(ERR_SHM);
 			goto done;
@@ -447,12 +439,14 @@ CK_RV ST_Initialize( void **FunctionList,
 		goto done;
 	}
 
-	/* no need to check for error here, we load what we can and syslog the rest */
+	/* no need to check for error here, we load what we can and
+	 * syslog the rest
+	 */
 	load_public_token_objects();
 
-	XProcLock( xproclock );
+	XProcLock();
 	global_shm->publ_loaded = TRUE;
-	XProcUnLock( xproclock );
+	XProcUnLock();
 
 	init_slotInfo();
 

--- a/usr/lib/pkcs11/tpm_stdll/tpm_specific.c
+++ b/usr/lib/pkcs11/tpm_stdll/tpm_specific.c
@@ -1595,9 +1595,9 @@ token_specific_login(CK_USER_TYPE userType, CK_CHAR_PTR pPin, CK_ULONG ulPinLen)
 
 		rc = load_private_token_objects();
 
-		XProcLock( xproclock );
+		XProcLock();
 		global_shm->priv_loaded = TRUE;
-		XProcUnLock( xproclock );
+		XProcUnLock();
 	} else {
 		/* SO path --
 		 */

--- a/usr/lib/pkcs11/tpm_stdll/utility.c
+++ b/usr/lib/pkcs11/tpm_stdll/utility.c
@@ -44,9 +44,7 @@
 #include "tok_spec_struct.h"
 #include "pkcs32.h"
 
-#if (SPINXPL)
 #include <sys/file.h>
-#endif
 
 
 
@@ -305,18 +303,6 @@ _CreateMutex( MUTEX *mutex )
 }
 
 CK_RV
-_CreateMsem( sem_t *msem )
-{
-	if (!sem_init( msem,0, 1)) // parm 2 non-0 means pshared  1 is unlocked 0 is locked
-		//if (!sem_init( msem,1, 1)) // parm 2 non-0 means pshared  1 is unlocked 0 is locked
-		return CKR_OK;
-	else{
-		OCK_LOG_ERR(ERR_FUNCTION_FAILED);
-		return CKR_FUNCTION_FAILED;
-	}
-}
-
-CK_RV
 _DestroyMutex( MUTEX *mutex )
 {
 	CK_RV  rc;
@@ -328,38 +314,11 @@ _DestroyMutex( MUTEX *mutex )
 }
 
 CK_RV
-_DestroyMsem( sem_t *msem )
-{
-	if (!sem_destroy(msem))
-		return CKR_OK;
-	else{
-		OCK_LOG_ERR(ERR_FUNCTION_FAILED);
-		return CKR_FUNCTION_FAILED;
-	}
-}
-
-
-CK_RV
 _LockMutex( MUTEX *mutex )
 {
 	pthread_mutex_lock( mutex);
 	return CKR_OK;
 
-}
-
-CK_RV
-_LockMsem( sem_t *msem )
-{
-	if (!msem){
-		OCK_LOG_ERR(ERR_FUNCTION_FAILED);
-		return CKR_FUNCTION_FAILED;
-	}
-	if(!sem_wait(msem)) // block until the semaphore is free
-		return CKR_OK;
-	else{
-		OCK_LOG_ERR(ERR_FUNCTION_FAILED);
-		return CKR_FUNCTION_FAILED;
-	}
 }
 
 CK_RV
@@ -370,49 +329,15 @@ _UnlockMutex( MUTEX *mutex )
 
 }
 
-CK_RV
-_UnlockMsem( sem_t *msem )
-{
-	if (!msem){
-		OCK_LOG_ERR(ERR_FUNCTION_FAILED);
-		return CKR_FUNCTION_FAILED;
-	}
-	if (!sem_post(msem))
-		return CKR_OK;
-	else{
-		OCK_LOG_ERR(ERR_FUNCTION_FAILED);
-		return CKR_FUNCTION_FAILED;
-	}
-}
-
-#if SYSVSEM
-#include <sys/sem.h>
-// These structures are needed to effect a lock
-// using SYS V semaphores...
-static struct sembuf xlock_lock[2]={
-	0,0,0,
-	0,1,SEM_UNDO
-};
-
-static struct sembuf xlock_unlock[1] = {
-	0,-1,(IPC_NOWAIT | SEM_UNDO)
-};
-
-static pthread_mutex_t  semmtx = PTHREAD_MUTEX_INITIALIZER;
-
-#endif
-
-
 int spinxplfd=-1;
 int spin_created=0;
 
 extern void set_perm(int);
 
 CK_RV
-CreateXProcLock(void *xproc)
+CreateXProcLock(void)
 {
 
-#if (SPINXPL)
 	// open the file that we will do the locking on...
 	spinxplfd = open("/tmp/.pkcs11spinloc",O_CREAT|O_APPEND|O_RDWR,
 			S_IRWXU|S_IRWXG|S_IRWXO);
@@ -425,86 +350,17 @@ CreateXProcLock(void *xproc)
 		perror("XPROC CREATE file :");
 	}
 	return CKR_OK;
-#elif  SYSVSEM
-	int  semid;
-	int *psem;
-	key_t  tok;
-
-	tok  = ftok( pk_dir, 'c' );
-
-	//printf("creating semaphore %x \n",tok);
-
-	psem = (int *)xproc;
-	if ( *psem < 0 ) {
-		if ( (semid = semget(tok,1,IPC_CREAT | 0666)) < 0 ){
-			if (errno == EEXIST) {
-				if ( (semid = semget(tok,0,0)) < 0) {
-					pthread_mutex_unlock(&semmtx);
-					OCK_LOG_ERR(ERR_FUNCTION_FAILED); 
-					return CKR_FUNCTION_FAILED;
-				}
-			} else {
-				pthread_mutex_unlock(&semmtx);
-				OCK_LOG_ERR(ERR_FUNCTION_FAILED); 
-				return CKR_FUNCTION_FAILED;
-			}
-		}
-	}
-	psem = (int *)xproc;
-	*psem = semid;
-	//pthread_mutex_unlock(&semmtx);
-	return CKR_OK;
-
-	// we know that semaphores are created unlocked
-#elif POSIXSEM 
-	return _CreateMsem((sem_t *)xproc);
-#elif PTHREADXPL
-	pthread_mutex_attr_t  mtxattr;
-
-	pthread_mutexattr_init(&mtxattr);
-	pthread_mutexattr_setpshared(&mtxattr,PTHREAD_PROCESS_SHARED);
-	pthread_mutex_init((pthread_mutex_t *)xproc,&mtxattr);
-
-#elif  NOXPROCLOCK
-	return CKR_OK;
-#else
-#error "Define XPROC LOCKS"
-
-#endif
-}
-CK_RV
-DestroyXProcLock(void *xproc)
-{
-#if SPINXPL
-	return CKR_OK;
-#elif SYSVSEM
-	int semid,*psem;
-
-	//printf("Destroying semaphore %x \n",xproc);
-
-	pthread_mutex_lock(&semmtx);
-	psem = (int *)xproc;
-	semid = *psem;
-
-	semctl(semid,1,IPC_RMID,0);
-	pthread_mutex_unlock(&semmtx);
-
-	return CKR_OK;
-#elif POSIXSEM 
-	return _DestroyMsem((sem_t *)xproc);
-#elif  PTHREADXPL
-	return pthread_mutex_destroy((pthread_mutex_t *)xproc);
-#elif  NOXPROCLOCK
-	return CKR_OK;
-#else
-#error "Define XPROC LOCKS"
-#endif
 }
 
 CK_RV
-XProcLock(void *xproc)
+DestroyXProcLock(void)
 {
-#if SPINXPL
+	return CKR_OK;
+}
+
+CK_RV
+XProcLock(void)
+{
 	if (!spin_created) {
 		spinxplfd = open("/tmp/.pkcs11spinloc",O_CREAT|O_APPEND|O_RDWR,
 				S_IRWXU|S_IRWXG|S_IRWXO);
@@ -515,33 +371,11 @@ XProcLock(void *xproc)
 		flock(spinxplfd,LOCK_EX);
 	}
 	return CKR_OK;
-#elif SYSVSEM
-	int semid,*psem;
-	pthread_mutex_lock(&semmtx);
-	return CKR_OK;
-
-	pthread_mutex_lock(&semmtx);
-	psem = (int *)xproc;
-	semid = *psem;
-	semop(semid,&xlock_lock[0],2);
-	pthread_mutex_unlock(&semmtx);
-	return CKR_OK;
-
-#elif POSIXSEM 
-	return _LockMsem((sem_t *)xproc);
-#elif PTHREADXPL
-	return _LockMutex((MUTEX *)xproc);
-#elif  NOXPROCLOCK
-	return CKR_OK;
-#else
-#error "Define XPROC LOCKS"
-
-#endif
 }
+
 CK_RV
-XProcUnLock(void *xproc)
+XProcUnLock(void)
 {
-#if SPINXPL
 	if (!spin_created) {
 		spinxplfd = open("/tmp/.pkcs11spinloc",O_CREAT|O_APPEND|O_RDWR,
 				S_IRWXU|S_IRWXG|S_IRWXO);
@@ -552,26 +386,6 @@ XProcUnLock(void *xproc)
 		flock(spinxplfd,LOCK_UN);
 	}
 	return CKR_OK;
-#elif SYSVSEM
-	int semid,*psem;
-	pthread_mutex_unlock(&semmtx);
-	return CKR_OK;
-
-	pthread_mutex_lock(&semmtx);
-	psem = (int *)xproc;
-	semid = *psem;
-	semop(semid,&xlock_unlock[0],1);
-	pthread_mutex_unlock(&semmtx);
-	return CKR_OK;
-#elif POSIXSEM 
-	return _UnlockMsem((sem_t *)xproc);
-#elif PTHREADXPL
-	return _UnlockMutex((MUTEX *)xproc);
-#elif  NOXPROCLOCK
-	return CKR_OK;
-#else
-#error "Define XPROC LOCKS"
-#endif
 }
 
 
@@ -947,23 +761,18 @@ attach_shm()
 		return CKR_FUNCTION_FAILED;
 	}
 	if (created == TRUE) {
-#if !(SYSVSEM)
 		// SYSV sem's are a global that is handled in the
 		// Initialize routine...  all others are stored in the
 		// shared memory segment so we have to do
 		// this here after the segment is created
 		// to prevent a core dump
-		CreateXProcLock( &global_shm->mutex );
-		xproclock = (void *)&global_shm->mutex; // need to do this here
-#endif
-		XProcLock( xproclock );
+		CreateXProcLock();
+		XProcLock();
 		global_shm->num_publ_tok_obj = 0;
 		global_shm->num_priv_tok_obj = 0;
 		memset( &global_shm->publ_tok_objs, 0x0, 2048 * sizeof(TOK_OBJ_ENTRY) );
 		memset( &global_shm->priv_tok_objs, 0x0, 2048 * sizeof(TOK_OBJ_ENTRY) );
-		XProcUnLock( xproclock );
-	} else {
-		xproclock = (void *)&global_shm->mutex;
+		XProcUnLock();
 	}
 #elif MMAP
 	{
@@ -1079,14 +888,12 @@ attach_shm()
 
 		global_shm = (LW_SHM_TYPE *)mmap(NULL,sizeof(LW_SHM_TYPE),PROT_READ|PROT_WRITE,MAP_SHARED,fd,0);
 		if (created == TRUE) {
-			XProcLock( xproclock );
+			XProcLock();
 			global_shm->num_publ_tok_obj = 0;
 			global_shm->num_priv_tok_obj = 0;
 			memset( &global_shm->publ_tok_objs, 0x0, 2048 * sizeof(TOK_OBJ_ENTRY) );
 			memset( &global_shm->priv_tok_objs, 0x0, 2048 * sizeof(TOK_OBJ_ENTRY) );
-			XProcUnLock( xproclock );
-		} else {
-			xproclock = (void *)&global_shm->mutex;
+			XProcUnLock();
 		}
 
 		rc = CKR_OK;

--- a/usr/sbin/pkcsslotd/Makefile.am
+++ b/usr/sbin/pkcsslotd/Makefile.am
@@ -3,11 +3,11 @@ sbin_PROGRAMS=pkcsslotd
 pkcsslotd_LDFLAGS = -lpthread
 
 # Not all versions of automake observe sbinname_CFLAGS
-pkcsslotd_CFLAGS = -DSPINXPL -DPROGRAM_NAME=\"$(@)\" -DNOODM -DNODAE \
+pkcsslotd_CFLAGS =  -DPROGRAM_NAME=\"$(@)\" -DNOODM -DNODAE \
 		   -I../. -I../../include/pkcs11 -I../../include/pkcs11/stdll
 
 # Not all versions of automake observe sbinname_CFLAGS
-AM_CFLAGS = -DSPINXPL -DPROGRAM_NAME=\"$(@)\" -DNOODM -DNODAE \
+AM_CFLAGS = -DPROGRAM_NAME=\"$(@)\" -DNOODM -DNODAE \
 	    -I../. -I../../include/pkcs11 -I../../include/pkcs11/stdll
 
 pkcsslotd_SOURCES = slotmgr.c shmem.c signal.c mutex.c err.c log.c daemon.c \

--- a/usr/sbin/pkcsslotd/garbage_linux.c
+++ b/usr/sbin/pkcsslotd/garbage_linux.c
@@ -550,24 +550,11 @@ BOOL CheckForGarbage ( Slot_Mgr_Shr_t *MemPtr ) {
 
   /* Grab the global Shared mem mutex since we might modify global_session_count */
 
-#if 1
-    Err = XProcLock(&(MemPtr->slt_mutex));
+    Err = XProcLock();
   if ( Err != TRUE ) {
     DbgLog (DL0, "Garbage collection: Locking attempt for global shmem mutex returned %s", SysConst(Err) );
     return FALSE;
   }
-#else
-#ifdef PKCS64
-  Err = msem_lock(&(MemPtr->slt_mutex),0);
-#else
-  Err = pthread_mutex_lock ( &(MemPtr->slt_mutex) );
-#endif
-
-  if ( Err != 0 ) {
-    DbgLog (DL0, "Garbage collection: Locking attempt for global shmem mutex returned %s", SysConst(Err) );
-    return FALSE;
-  }
-#endif
 
   #ifdef DEV
   DbgLog ( DL5, "Garbage collection: Got global shared memory lock");
@@ -690,16 +677,7 @@ BOOL CheckForGarbage ( Slot_Mgr_Shr_t *MemPtr ) {
     
   } /* end for ProcIndex */
   
-#if 1
-  XProcUnLock(&(MemPtr->slt_mutex));
-#else
-#ifdef PKCS64
-  msem_unlock(&(MemPtr->slt_mutex),0);
-#else
-  pthread_mutex_unlock ( &(MemPtr->slt_mutex) );
-#endif
-#endif
-
+  XProcUnLock();
   DbgLog ( DL5, "Garbage collection: Released global shared memory lock");
 
   return TRUE;

--- a/usr/sbin/pkcsslotd/pkcsslotd.h
+++ b/usr/sbin/pkcsslotd/pkcsslotd.h
@@ -533,11 +533,11 @@ BOOL                   ReadSlotInfoDB ( void );
 
 
 /* Cross Process locking */
-int  XProcLock(void *);
-int  XProcUnLock(void *);
+int  XProcLock(void);
+int  XProcUnLock(void);
 
-int  CreateXProcLock(void *);
-int  DestroyXProcLock(void *);
+int  CreateXProcLock(void);
+int  DestroyXProcLock(void);
 
 
 #endif /* _SLOTMGR_H */

--- a/usr/sbin/pkcsslotd/slotmgr.c
+++ b/usr/sbin/pkcsslotd/slotmgr.c
@@ -388,28 +388,13 @@ int main ( int argc, char *argv[], char *envp[]) {
 
    /* Get the global shared memory mutex */
 
-#if 1
-   XProcLock(&(shmp->slt_mutex));
-#else
-#ifdef PKCS64
-   msem_lock(&(shmp->slt_mutex),0);
-#else
-   pthread_mutex_lock(&(shmp->slt_mutex));
-#endif
-#endif
+   XProcLock();
 
    /* Populate the Shared Memory Region */
    if ( ! InitSharedMemory(shmp) ) {
 
-#if 1
-      XProcUnLock(&(shmp->slt_mutex));
-#else
-#ifdef PKCS64
-     msem_unlock(&(shmp->slt_mutex),0);
-#else
-     pthread_mutex_unlock(&(shmp->slt_mutex));
-#endif
-#endif
+      XProcUnLock();
+
      DetachFromSharedMemory();
      DestroySharedMemory();
      return 4;
@@ -417,15 +402,7 @@ int main ( int argc, char *argv[], char *envp[]) {
    
    /* Release the global shared memory mutex */
 
-#if 1
-      XProcUnLock(&(shmp->slt_mutex));
-#else
-#ifdef PKCS64
-   msem_unlock(&(shmp->slt_mutex),0);
-#else
-   pthread_mutex_unlock(&(shmp->slt_mutex));
-#endif
-#endif
+      XProcUnLock();
 
    #if TEST_MUTEXES
    DumpSharedMemory();


### PR DESCRIPTION
access to global shared memory and only use spinlock scheme.

Signed-off-by: Joy Latten jmlatten@users.sourceforge.net
