### PR TITLE
Add a Java-based sign and verify testcase.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -658,6 +658,8 @@ AC_CONFIG_FILES([Makefile usr/Makefile \
 	  testcases/common/Makefile \
 	  testcases/driver/Makefile \
 	  testcases/init_tok/Makefile \
+	  testcases/java/opencryptoki_java_test.sh \
+	  testcases/java/Makefile \
 	  testcases/mkobj/Makefile \
 	  testcases/oc-digest/Makefile \
 	  testcases/rsa_keygen/Makefile \
@@ -677,7 +679,7 @@ AC_CONFIG_FILES([Makefile usr/Makefile \
 	  man/man7/Makefile \
 	  man/man7/opencryptoki.7 \
 	  man/man8/Makefile \
-	  man/man8/pkcsslotd.8])
+	  man/man8/pkcsslotd.8], [chmod +x testcases/java/opencryptoki_java_test.sh])
 AC_OUTPUT
 
 echo "Enabled features:"

--- a/testcases/Makefile.am
+++ b/testcases/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS=common driver init_tok mkobj oc-digest rsa_keygen rsa_test speed test_crypto threadmkobj tok_obj v2.11 login
+SUBDIRS=common driver init_tok mkobj oc-digest rsa_keygen rsa_test speed test_crypto threadmkobj tok_obj v2.11 login java
 
 noinst_SCRIPTS = ock_tests.sh init_token.sh
 

--- a/testcases/java/Makefile.am
+++ b/testcases/java/Makefile.am
@@ -1,0 +1,3 @@
+JAVAROOT=..
+testdir=..
+test_JAVA=opencryptoki_java_test.java NullPrompter.java

--- a/testcases/java/NullPrompter.java
+++ b/testcases/java/NullPrompter.java
@@ -1,0 +1,47 @@
+
+//package com.ibm.crypto.pkcs11impl.provider;
+
+import javax.security.auth.callback.Callback;
+import java.io.IOException;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import javax.security.auth.callback.*;
+
+public class NullPrompter implements javax.security.auth.callback.CallbackHandler {
+
+    private String userName;
+    private char[] authenticator;
+
+    private NullPrompter() { // hide the null constructor, since we're not prompting!
+    }
+
+    public NullPrompter(String userName, char authenticator[]) {
+        this.userName = userName;
+        this.authenticator = authenticator;
+    }
+
+    public void nukeEm() {
+        this.userName = null;
+        for (int i = 0; i < authenticator.length; i++)
+                    authenticator[i] = ' ';
+    }
+
+    public void handle(Callback[] callbacks)
+    throws IOException, UnsupportedCallbackException {
+
+            for (int i = 0; i < callbacks.length; i++) {
+            if (callbacks[i] instanceof TextOutputCallback) {
+
+            } else if (callbacks[i] instanceof TextInputCallback) {
+                ((TextInputCallback)callbacks[i]).setText(userName);
+
+            } else if (callbacks[i] instanceof PasswordCallback) {
+            ((PasswordCallback)callbacks[i]).setPassword(authenticator);
+            } else {
+                throw new UnsupportedCallbackException
+                        (callbacks[i], "Unrecognized Callback");
+            }
+        }
+    }
+}

--- a/testcases/java/opencryptoki_java_test.java
+++ b/testcases/java/opencryptoki_java_test.java
@@ -1,0 +1,289 @@
+
+/*
+ * opencryptoki_java_test.java
+ *
+ * This testcase generates 2 keys, one through the PKCS11 provider and one through the JCE. It
+ * then creates a signature over arbitrary data using the JCE and verifies using PKCS11 and
+ * vice versa. This will test whether openCryptoki is generating signatures correctly.
+ *
+ * It can test the following mechanisms:
+ * CKM_SHA256_RSA_PKCS
+ * CKM_SHA1_RSA_PKCS
+ * CKM_MD5_RSA_PKCS
+ *
+ * It will test the following RSA key sizes:
+ * 512
+ * 1024
+ * 2048
+ * 4096
+ *
+ * Note that this test doesn't work on secure-key tokens. When the verify step is executed,
+ * opencryptoki will fail to find the key object's CKA_IBM_OPAQUE attribute, since the public
+ * key is generated through the JCE for half of these tests. This bug has been opened to fix
+ * this issue: http://sf.net/tracker/?func=detail&aid=3439616&group_id=128009&atid=710344
+ *
+ * Kent Yoder <yoder1@us.ibm.com>
+ */
+
+import java.io.*;
+import java.security.*;
+
+import java.security.spec.*;
+import java.security.interfaces.*;
+import javax.crypto.*;
+import com.ibm.crypto.pkcs11impl.provider.IBMPKCS11Impl;
+
+import java.util.Iterator;
+
+
+public class opencryptoki_java_test
+{
+	com.ibm.crypto.pkcs11impl.provider.IBMPKCS11Impl ibm_pkcs11impl;
+
+	Provider provider;
+	Provider jceProvider;
+	String providerNameString;
+	String jceProviderNameString;
+
+	opencryptoki_java_test(String conf)
+	{
+		initializeProvider(conf);
+	}
+
+	void  initializeProvider(String conf)
+	{
+		try
+		{
+			ibm_pkcs11impl = new com.ibm.crypto.pkcs11impl.provider.IBMPKCS11Impl(conf);
+		}
+		catch (Exception e)
+		{
+			System.out.println("Error creating provider object: " + e.getMessage());
+			System.out.println("Make sure pkcsslotd is running and that pkcsconf -t " +
+					   "shows that your token is available");
+			System.exit(-1);
+		}
+
+		Security.insertProviderAt(ibm_pkcs11impl, 1);
+
+		provider = Security.getProvider("IBMPKCS11Impl-Sample");
+		jceProvider = Security.getProvider("IBMJCE");
+		providerNameString = "IBMPKCS11Impl-Sample";
+		jceProviderNameString = "IBMJCE";
+
+
+		if (provider != null)
+		{
+			System.out.println("The provider object used by this test is: " +
+					   provider.getName());
+			System.out.println("Provider version number is: " + provider.getVersion());
+			System.out.println("Provider info is: " + provider.getInfo());
+			System.out.println("The provider was loaded successfully.");
+		}
+		else
+		{
+			System.out.println("The provider was not found.");
+			System.out.println("The loading of the provider FAILED.");
+			System.exit(-1);
+		}
+
+		String pswd = System.getenv("PKCS11_USER_PIN");
+		if (pswd == null) {
+			System.out.println("Please set the PKCS11_USER_PIN env var to the " +
+					   "CKU_USER PIN");
+			System.exit(-1);
+		}
+		char [] passwd = new char[pswd.length()];
+		pswd.getChars(0,pswd.length(),passwd,0);
+		NullPrompter np = new NullPrompter(null, passwd);
+		try
+		{
+			ibm_pkcs11impl.login(null, np);
+		}
+		catch(Exception e)
+		{
+			System.out.println("Login to crypto adapter failed.  EXITING.");
+			System.exit(-1);
+		}
+	}
+
+	public static void sign_verify(String   hash,
+			int      key_len,
+			byte[]   data_to_sign,
+			String   provider)
+	{
+		int i, perf_runs;
+		KeyPairGenerator kg;
+		KeyPair kp;
+		Signature jce_sig, p11_sig;
+		byte[] jce_digest, p11_digest;
+		boolean bVerify;
+		byte[] sig;
+
+		/* ================  TEST 1 ==================*/
+		/* Try generating a hash object first, since keygen takes awhile and we may not
+		 * even support this mechanism */
+		try {
+			jce_sig = java.security.Signature.getInstance(hash, "IBMJCE");
+			p11_sig = java.security.Signature.getInstance(hash, provider);
+		} catch (Exception e) {
+			System.out.println(e);
+			return;
+		}
+
+		System.out.println("Created a " + hash + " object");
+
+		try {
+			kg = KeyPairGenerator.getInstance("RSA", "IBMJCE");
+			kg.initialize(key_len);
+			kp = kg.generateKeyPair();
+		}
+		catch (Exception e)
+		{
+			System.out.println(e);
+			return;
+		}
+
+		System.out.println("Generated a " + key_len + "-bit JCE key");
+
+		/* sign using JCE */
+		try {
+			jce_sig.initSign(kp.getPrivate());
+			jce_sig.update(data_to_sign);
+			sig = jce_sig.sign();
+		}
+		catch (Exception e)
+		{
+			System.out.println(e);
+			return;
+		}
+
+		System.out.println("Signed the " + hash + " object using JCE");
+
+		/* verify using P11 */
+		try {
+			p11_sig.initVerify(kp.getPublic());
+			p11_sig.update(data_to_sign);
+			bVerify = p11_sig.verify(sig);
+		}
+		catch (Exception e)
+		{
+			System.out.println(e);
+			return;
+		}
+
+		if (!bVerify) {
+			System.out.println("Verification of JCE signature on P11 failed!");
+		} else {
+			System.out.println("Verified the " + hash + " object using P11: Success!");
+		}
+
+		/* ================  TEST 2 ==================*/
+		try {
+			kg = KeyPairGenerator.getInstance("RSA", provider);
+			kg.initialize(key_len);
+			kp = kg.generateKeyPair();
+		}
+		catch (Exception e)
+		{
+			System.out.println(e);
+			return;
+		}
+
+		System.out.println("Generated a " + key_len + "-bit P11 key");
+
+		try {
+			p11_sig = java.security.Signature.getInstance(hash, provider);
+			jce_sig = java.security.Signature.getInstance(hash, "IBMJCE");
+		}
+		catch (Exception e)
+		{
+			System.out.println(e);
+			return;
+		}
+
+		System.out.println("Created a " + hash + " object");
+
+		/* sign using P11 */
+		try {
+			p11_sig.initSign(kp.getPrivate());
+			p11_sig.update(data_to_sign);
+			sig = p11_sig.sign();
+		}
+		catch (Exception e)
+		{
+			System.out.println(e);
+			return;
+		}
+
+		System.out.println("Signed the " + hash + " object using P11");
+
+		/* verify using JCE */
+		try {
+			jce_sig.initVerify(kp.getPublic());
+			jce_sig.update(data_to_sign);
+			bVerify = jce_sig.verify(sig);
+		}
+		catch (Exception e)
+		{
+			System.out.println(e);
+			return;
+		}
+
+		if (!bVerify) {
+			System.out.println("Verification of P11 signature on JCE failed!");
+		} else {
+			System.out.println("Verified the " + hash + " object using JCE: Success!");
+		}
+	}
+
+
+	public static void main(String argv[])
+	{
+		byte[] data = new byte[139]; /* this data will be hashed */
+
+		if (argv.length != 2)
+		{
+			System.out.println("usage: opencryptoki_java_test <mechanism> " +
+					   "<config file>");
+			return;
+		}
+
+		opencryptoki_java_test test = new opencryptoki_java_test(argv[1]);
+
+		if (argv[0].equals("CKM_SHA256_RSA_PKCS")) {
+			test.sign_verify("SHA256withRSA", 512,  data, "IBMPKCS11Impl-Sample");
+			test.sign_verify("SHA256withRSA", 1024, data, "IBMPKCS11Impl-Sample");
+			test.sign_verify("SHA256withRSA", 2048, data, "IBMPKCS11Impl-Sample");
+			test.sign_verify("SHA256withRSA", 4096, data, "IBMPKCS11Impl-Sample");
+		} else if (argv[0].equals("CKM_SHA1_RSA_PKCS")) {
+			test.sign_verify("SHA1withRSA", 512,  data, "IBMPKCS11Impl-Sample");
+			test.sign_verify("SHA1withRSA", 1024, data, "IBMPKCS11Impl-Sample");
+			test.sign_verify("SHA1withRSA", 2048, data, "IBMPKCS11Impl-Sample");
+			test.sign_verify("SHA1withRSA", 4096, data, "IBMPKCS11Impl-Sample");
+		} else if (argv[0].equals("CKM_MD5_RSA_PKCS")) {
+			test.sign_verify("MD5withRSA", 512,  data, "IBMPKCS11Impl-Sample");
+			test.sign_verify("MD5withRSA", 1024, data, "IBMPKCS11Impl-Sample");
+			test.sign_verify("MD5withRSA", 2048, data, "IBMPKCS11Impl-Sample");
+			test.sign_verify("MD5withRSA", 4096, data, "IBMPKCS11Impl-Sample");
+		} else {
+			System.out.println("Unknown mechanism: " + argv[0]);
+		}
+	}
+
+	public static void showProviders()
+	{
+		java.security.Provider[] providers = Security.getProviders();
+		System.out.println("\n\n\n================================================");
+		System.out.println("The security provider's list is:");
+		for (int i=0; i<providers.length; ++i) {
+			System.out.print("provider \"");
+			System.out.print(providers[i].getName());
+			System.out.print("\": ");
+			System.out.println(providers[i].toString());
+			System.out.println();
+		}
+
+		System.out.println("================================================\n\n\n");
+	}
+}

--- a/testcases/java/opencryptoki_java_test.sh.in
+++ b/testcases/java/opencryptoki_java_test.sh.in
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# java sign/verify testing script
+#
+# The caller of this script should know that it only works on tokens that will allow a public
+# key to be imported
+#
+# The purpose of this script is to:
+# 1. query a token to see what mechanisms it supports and run the test once per mechanism
+# 2. generate a java PKCS11 config file (see run_test) to point java to the API .so
+#
+# Kent Yoder <yoder1@us.ibm.com>
+#
+
+GLOBAL_RC=0
+LIBRARY_PATH=@libdir@/opencryptoki/libopencryptoki.so
+CFG_FILE=opencryptoki_java.cfg
+
+NUM_MECHS=5
+MECHS[0]="CKM_SHA1_RSA_PKCS"
+MECHS[1]="CKM_MD5_RSA_PKCS"
+MECHS[2]="CKM_SHA256_RSA_PKCS"
+MECHS[3]="CKM_SHA384_RSA_PKCS"
+MECHS[4]="CKM_SHA512_RSA_PKCS"
+#MECHS[5]="CKM_ECDSA_SHA1"
+
+# usage: run_test <mechanism> <slot id>
+function run_test
+{
+	echo "name=Sample" > $CFG_FILE
+	echo "slot=$2" >> $CFG_FILE
+	echo "library=$LIBRARY_PATH" >> $CFG_FILE
+
+	## generate a software key, sign with it, verify using p11
+	## generate a p11 key, sign with it, verify using openssl
+	java opencryptoki_java_test $1 $CFG_FILE
+}
+
+#set -x
+
+#
+# main()
+#
+SLOT_ID=0
+NOSTOP=0
+
+#
+# Check for -slot, -nostop params
+#
+while test "x$1" != "x"; do
+	if test "x$1" == "x-slot"; then
+		if test "x$2" != "x"; then
+			shift
+			SLOT_ID=$1
+			shift
+			continue
+		else
+			usage $0
+		fi
+	elif test "x$1" == "x-nostop"; then
+		shift
+		NOSTOP=1
+	else
+		usage $0
+	fi
+done
+
+# for each mechanism
+for i in $(seq 0 $(( $NUM_MECHS - 1)))
+do
+	pkcsconf -c $SLOT_ID -m | grep ${MECHS[i]}
+	if test $? -eq 0; then
+		run_test ${MECHS[i]} $SLOT_ID
+	fi
+
+done
+
+exit $GLOBAL_RC
+

--- a/testcases/ock_tests.sh.in
+++ b/testcases/ock_tests.sh.in
@@ -56,7 +56,7 @@ TOKTYPE=""
 #
 # v2.11/login MUST come last if it appears in this list
 #
-OCK_TESTS="oc-digest/digest_tests.sh driver/*tests"
+OCK_TESTS="oc-digest/digest_tests.sh driver/*tests java/opencryptoki_java_test.sh"
 OCK_BENCHS="driver/*bench"
 
 usage()


### PR DESCRIPTION
This patch adds a java testcase to the testsuite under testcases/java.  Its been integrated into the auotmated testsuite script, which might raise some questions, since running the automated tests will require an IBM JVM from here on out.

The test itself iterates through key sizes and for each one, it generates a key using the Java JCE, signs with it, and then verifies using the PKCS11 provider, which is directed to an opencryptoki token.  Also included in this patch is a script that queries the token being tested to find out which signing mechanisms it supports. Note that this test doesn't work with secure-key tokens.

Signed-off-by: Kent Yoder key@linux.vnet.ibm.com
